### PR TITLE
Support semantic tokens

### DIFF
--- a/Marksman.sln.DotSettings
+++ b/Marksman.sln.DotSettings
@@ -1,2 +1,3 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
-	<s:Boolean x:Key="/Default/UserDictionary/Words/=Compl/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Compl/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Semato/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/Marksman/Marksman.fsproj
+++ b/Marksman/Marksman.fsproj
@@ -14,6 +14,7 @@
         <Compile Include="Index.fs" />
         <Compile Include="Workspace.fs" />
         <Compile Include="Compl.fs" />
+        <Compile Include="Semato.fs" />
         <Compile Include="Diag.fs" />
         <Compile Include="State.fs" />
         <Compile Include="Server.fs" />

--- a/Marksman/Semato.fs
+++ b/Marksman/Semato.fs
@@ -53,7 +53,7 @@ module Token =
                     else
                         curTok.range.Start.Character
 
-                assert (deltaChar > 0)
+                assert (deltaChar >= 0)
 
                 deltaLine, deltaChar
 

--- a/Marksman/Semato.fs
+++ b/Marksman/Semato.fs
@@ -24,7 +24,10 @@ module TokenType =
 
     let mapping = [| WikiLink; RefLink |] |> Array.map toLspName
 
-type Token = { range: Range; typ: TokenType }
+type Token =
+    { range: Range
+      typ: TokenType }
+    override this.ToString() = $"{this.typ}@{this.range.DebuggerDisplay}"
 
 module Token =
     // We don't use modifiers in the encoding currently

--- a/Tests/Helpers.fs
+++ b/Tests/Helpers.fs
@@ -1,0 +1,20 @@
+module Marksman.Helpers
+
+open System.Runtime.InteropServices
+open Snapper
+open Marksman.Misc
+
+let dummyRoot =
+    if RuntimeInformation.IsOSPlatform(OSPlatform.Windows) then
+        "c:/"
+    else
+        "/"
+
+let dummyRootPath pathComps = dummyRoot :: pathComps |> String.concat "/"
+
+let pathToUri path = $"file://{path}"
+
+let checkInlineSnapshot (fmt: 'a -> string) (things: seq<'a>) (snapshot: seq<string>) =
+    let lines = Seq.map (fun x -> (fmt x).Lines()) things |> Seq.concat
+
+    lines.ShouldMatchInlineSnapshot(snapshot)

--- a/Tests/ParserTests.fs
+++ b/Tests/ParserTests.fs
@@ -9,6 +9,7 @@ open Xunit
 open Marksman.Cst
 open Marksman.Parser
 open Marksman.Misc
+open Marksman.Helpers
 
 let checkSnapshot (document: array<Element>) =
     let lines =
@@ -16,11 +17,7 @@ let checkSnapshot (document: array<Element>) =
 
     lines.ShouldMatchSnapshot()
 
-let checkInlineSnapshot (document: array<Element>) snapshot =
-    let lines =
-        Array.map (fun x -> (Element.fmt x).Lines()) document |> Array.concat
-
-    lines.ShouldMatchInlineSnapshot(snapshot)
+let checkInlineSnapshot = checkInlineSnapshot Element.fmt
 
 let scrapeString content = parseText (Text.mkText content)
 

--- a/Tests/SematoTests.fs
+++ b/Tests/SematoTests.fs
@@ -16,13 +16,15 @@ let testEncoding () =
     let content =
         """# Title
 Start with [[a-wiki-link]]. Then a [ref-link].
+[[wiki-at-sol]]
 <blank>
 End with [[wiki-link-no-eol]]"""
 
     let doc = Doc.mk docPath folderPath None (Text.mkText content)
     let data = Token.ofIndexEncoded doc.index
-    Assert.Equal(3 * 5, data.Length)
+    Assert.Equal(4 * 5, data.Length)
 
     Assert.Equal<uint32>([| 1u; 11u; 15u; 0u; 0u |], nthToken data 0)
     Assert.Equal<uint32>([| 0u; 25u; 8u; 1u; 0u |], nthToken data 1)
-    Assert.Equal<uint32>([| 2u; 9u; 20u; 0u; 0u |], nthToken data 2)
+    Assert.Equal<uint32>([| 1u; 0u; 15u; 0u; 0u |], nthToken data 2)
+    Assert.Equal<uint32>([| 2u; 9u; 20u; 0u; 0u |], nthToken data 3)

--- a/Tests/SematoTests.fs
+++ b/Tests/SematoTests.fs
@@ -1,0 +1,28 @@
+module Marksman.SematoTests
+
+open Marksman.Misc
+open Marksman.Helpers
+open Marksman.Workspace
+open Marksman.Semato
+open Xunit
+
+let folderPath = PathUri.fromString (dummyRootPath [ "folder" ])
+let nthToken (data: array<uint32>) n = data[n * 5 .. n * 5 + 4]
+
+[<Fact>]
+let testEncoding () =
+    let docPath = dummyRootPath [ "folder"; "doc1.md" ] |> PathUri.fromString
+
+    let content =
+        """# Title
+Start with [[a-wiki-link]]. Then a [ref-link].
+<blank>
+End with [[wiki-link-no-eol]]"""
+
+    let doc = Doc.mk docPath folderPath None (Text.mkText content)
+    let data = Token.ofIndexEncoded doc.index
+    Assert.Equal(3 * 5, data.Length)
+
+    Assert.Equal<uint32>([| 1u; 11u; 15u; 0u; 0u |], nthToken data 0)
+    Assert.Equal<uint32>([| 0u; 25u; 8u; 1u; 0u |], nthToken data 1)
+    Assert.Equal<uint32>([| 2u; 9u; 20u; 0u; 0u |], nthToken data 2)

--- a/Tests/Tests.fsproj
+++ b/Tests/Tests.fsproj
@@ -8,11 +8,13 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <Compile Include="Helpers.fs" />
         <Compile Include="ParserTests.fs" />
         <Compile Include="TextTests.fs" />
         <Compile Include="MiscTests.fs" />
         <Compile Include="DiagTest.fs" />
         <Compile Include="ComplTests.fs" />
+        <Compile Include="SematoTests.fs" />
         <Compile Include="WorkspaceTest.fs" />
         <Compile Include="Program.fs" />
     </ItemGroup>

--- a/Tests/WorkspaceTest.fs
+++ b/Tests/WorkspaceTest.fs
@@ -1,6 +1,5 @@
 module Marksman.WorkspaceTest
 
-open System.Runtime.InteropServices
 open Ionide.LanguageServerProtocol.Types
 
 open Xunit
@@ -8,18 +7,12 @@ open Xunit
 open Marksman.Misc
 open Marksman.Workspace
 
+open Marksman.Helpers
+
 module DocTest =
-    let dummyRoot =
-        if RuntimeInformation.IsOSPlatform(OSPlatform.Windows) then
-            "c:/"
-        else
-            "/"
-
-    let mkDummyPath components = dummyRoot + (components |> String.concat "/")
-
     [<Fact>]
     let applyLspChange () =
-        let dummyPath = (mkDummyPath [ "dummy.md" ])
+        let dummyPath = (dummyRootPath [ "dummy.md" ])
 
         let empty =
             Doc.mk
@@ -29,7 +22,7 @@ module DocTest =
                 (Text.mkText "")
 
         let insertChange =
-            { TextDocument = { Uri = $"file://{dummyPath}"; Version = Some 1 }
+            { TextDocument = { Uri = pathToUri dummyPath; Version = Some 1 }
               ContentChanges =
                 [| { Range = Some(Range.Mk(0, 0, 0, 0))
                      RangeLength = Some 0


### PR DESCRIPTION
Add basic support for single-line semantic tokens. The server now supports both `full` and `range` requests, but NOT `full/delta`. This should be fine, however, as the # of tokens should be low bc. it's only wiki links and reference links.