### PR TITLE
feat: Generate table of contents code action

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 Marksman.sln.DotSettings.user
 **/bin
 **/obj
+
+.fake

--- a/LanguageServerProtocol/LanguageServerProtocol.fs
+++ b/LanguageServerProtocol/LanguageServerProtocol.fs
@@ -358,7 +358,7 @@ module Server =
       "workspace/willDeleteFiles", requestHandling (fun s p -> s.WorkspaceWillDeleteFiles(p))
       "workspace/didDeleteFiles", requestHandling (fun s p -> s.WorkspaceDidDeleteFiles(p) |> notificationSuccess)
       "workspace/symbol", requestHandling (fun s p -> s.WorkspaceSymbol(p))
-      "workspace/executeCommand ", requestHandling (fun s p -> s.WorkspaceExecuteCommand(p))
+      "workspace/executeCommand", requestHandling (fun s p -> s.WorkspaceExecuteCommand(p))
       "shutdown", requestHandling (fun s () -> s.Shutdown() |> notificationSuccess)
       "exit", requestHandling (fun s () -> s.Exit() |> notificationSuccess) ]
     |> Map.ofList

--- a/Marksman/Marksman.fsproj
+++ b/Marksman/Marksman.fsproj
@@ -15,6 +15,7 @@
     <Compile Include="Semato.fs" />
     <Compile Include="Diag.fs" />
     <Compile Include="State.fs" />
+    <Compile Include="Toc.fs" />
     <Compile Include="Server.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>

--- a/Marksman/Marksman.fsproj
+++ b/Marksman/Marksman.fsproj
@@ -1,39 +1,34 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-
-    <PropertyGroup>
-        <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
-        <AssemblyName>marksman</AssemblyName>
-    </PropertyGroup>
-
-    <ItemGroup>
-        <Compile Include="Misc.fs" />
-        <Compile Include="Text.fs" />
-        <Compile Include="Cst.fs" />
-        <Compile Include="Parser.fs" />
-        <Compile Include="Index.fs" />
-        <Compile Include="Workspace.fs" />
-        <Compile Include="Compl.fs" />
-        <Compile Include="Semato.fs" />
-        <Compile Include="Diag.fs" />
-        <Compile Include="State.fs" />
-        <Compile Include="Server.fs" />
-        <Compile Include="Program.fs" />
-    </ItemGroup>
-
-    <ItemGroup>
-        <PackageReference Update="FSharp.Core" Version="6.0.4" />
-        <PackageReference Include="FSharp.SystemCommandLine" Version="0.10.0-beta" />
-        <PackageReference Include="FSharpPlus" Version="1.2.3" />
-        <PackageReference Include="Markdig" Version="0.30.2" />
-        <!--        <PackageReference Include="Ionide.LanguageServerProtocol" Version="0.3.1" />-->
-        <PackageReference Include="Serilog" Version="2.11.0" />
-        <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
-    </ItemGroup>
-
-    <ItemGroup>
-        <ProjectReference Include="..\LanguageServerProtocol\LanguageServerProtocol.fsproj" />
-        <ProjectReference Include="..\MarkdigPatches\MarkdigPatches.csproj" />
-    </ItemGroup>
-
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <AssemblyName>marksman</AssemblyName>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Misc.fs" />
+    <Compile Include="Text.fs" />
+    <Compile Include="Cst.fs" />
+    <Compile Include="Parser.fs" />
+    <Compile Include="Index.fs" />
+    <Compile Include="Workspace.fs" />
+    <Compile Include="Compl.fs" />
+    <Compile Include="Semato.fs" />
+    <Compile Include="Diag.fs" />
+    <Compile Include="State.fs" />
+    <Compile Include="Server.fs" />
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Update="FSharp.Core" Version="6.0.4" />
+    <PackageReference Include="FSharp.SystemCommandLine" Version="0.10.0-beta" />
+    <PackageReference Include="FSharpPlus" Version="1.2.3" />
+    <PackageReference Include="Markdig" Version="0.30.2" />
+    <!--        <PackageReference Include="Ionide.LanguageServerProtocol" Version="0.3.1" />-->
+    <PackageReference Include="Serilog" Version="2.11.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\LanguageServerProtocol\LanguageServerProtocol.fsproj" />
+    <ProjectReference Include="..\MarkdigPatches\MarkdigPatches.csproj" />
+  </ItemGroup>
 </Project>

--- a/Marksman/Server.fs
+++ b/Marksman/Server.fs
@@ -725,16 +725,14 @@ type MarksmanServer(client: MarksmanClient) =
         let state = requireState ()
         let docPath = opts.TextDocument.Uri |> PathUri.fromString
 
-        let documentBeginning =
-            { Start = { Line = 0; Character = 0 }
-              End = { Line = 0; Character = 0 } }
+        let documentBeginning = Range.Mk(0, 0, 0, 0)
 
         let editAt rangeOpt text =
             let textEdit =
                 { NewText = text
                   Range = Option.defaultValue documentBeginning rangeOpt }
 
-            let mp = Map.empty.Add(opts.TextDocument.Uri, [| textEdit |])
+            let mp = Map.ofList [ opts.TextDocument.Uri, [| textEdit |] ]
 
             { Changes = Some mp; DocumentChanges = None }
 
@@ -768,7 +766,7 @@ type MarksmanServer(client: MarksmanClient) =
                 match existing with
                 | None -> [| codeAction "Create a Table of Contents" (editAt None render) |]
                 | Some (oldTocRange) ->
-                    [| codeAction "Update Table of Contents" (editAt (Some oldTocRange) render) |]
+                    [| codeAction "Update the Table of Contents" (editAt (Some oldTocRange) render) |]
 
         let commands = TextDocumentCodeActionResult.CodeActions codeActions
 

--- a/Marksman/Server.fs
+++ b/Marksman/Server.fs
@@ -753,7 +753,7 @@ type MarksmanServer(client: MarksmanClient) =
                 let rendered = TableOfContents.render toc
                 let detected = TableOfContents.detect document.text
 
-                let result = ($"{rendered}\n", detected)
+                let result = ($"{rendered}", detected)
 
                 result
             }

--- a/Marksman/Server.fs
+++ b/Marksman/Server.fs
@@ -725,8 +725,6 @@ type MarksmanServer(client: MarksmanClient) =
         let state = requireState ()
         let docPath = opts.TextDocument.Uri |> PathUri.fromString
 
-        let p = State.tryFindDocument docPath state
-
         let toc =
             monad' {
                 let! document = State.tryFindDocument docPath state

--- a/Marksman/Server.fs
+++ b/Marksman/Server.fs
@@ -731,19 +731,12 @@ type MarksmanServer(client: MarksmanClient) =
 
         let editAt rangeOpt text =
             let textEdit =
-                match rangeOpt with
-                | None -> { NewText = text; Range = documentBeginning }
-                | Some (range) -> { NewText = text; Range = range }
+                { NewText = text
+                  Range = Option.defaultValue documentBeginning rangeOpt }
 
             let mp = Map.empty.Add(opts.TextDocument.Uri, [| textEdit |])
 
             { Changes = Some mp; DocumentChanges = None }
-
-        let existing =
-            State.tryFindDocument docPath state
-            |> Option.map (fun x -> x.text)
-            |> Option.bind TableOfContents.detect
-
 
         let toc =
             monad' {

--- a/Marksman/Text.fs
+++ b/Marksman/Text.fs
@@ -99,6 +99,8 @@ type Text =
 
         Range.Mk(line, 0, line, end_ - start)
 
+    member this.LineContent(line: int) : string = this.Substring(this.LineContentRange(line))
+
     member this.FullRange() : Range =
         let lineNum = this.lineMap.Map.Length - 1
         let start = { Line = 0; Character = 0 }

--- a/Marksman/Toc.fs
+++ b/Marksman/Toc.fs
@@ -3,6 +3,11 @@ module Marksman.Toc
 open Marksman.Misc
 open Marksman.Index
 open Marksman.Cst
+open Marksman.Text
+open Ionide.LanguageServerProtocol.Types
+
+[<Literal>]
+let Marker = """<!--toc-->"""
 
 type Title = string
 type EntryLevel = int
@@ -23,11 +28,50 @@ type TableOfContents = { Entries: Entry[] }
 
 module TableOfContents =
     let mk (index: Index) : TableOfContents option =
-        let headings = index.titles |> Array.map (fun x -> x.data)
+        let headings = index.headings |> Array.map (fun x -> x.data)
 
-        if index.titles.Length.Equals 0 then
+        if index.headings.Length.Equals 0 then
             None
         else
             Some { Entries = Array.map Entry.fromHeading headings }
 
-    let render (toc: TableOfContents) = Array.map Entry.renderLink toc.Entries |> String.concat "\n"
+    let render (toc: TableOfContents) =
+        Marker
+        + "\n"
+        + (Array.map Entry.renderLink toc.Entries |> String.concat "\n")
+
+
+    type State =
+        | BeforeMarker
+        | Collecting of Range
+
+
+    let detect (text: Text) : Range option =
+        let lines = text.lineMap
+        let maxIndex = lines.NumLines
+
+        let rec go i st =
+            if i.Equals(maxIndex) then
+                st
+            else
+                let lineRange = text.LineContentRange(i)
+                let lineContent = text.LineContent(i)
+
+                match st with
+                // if we found the marker, start collecting text from here
+                | BeforeMarker when lineContent.Equals(Marker) -> go (i + 1) (Collecting lineRange)
+                // if we are in collecting mode, just expand the selection
+                | Collecting (range) ->
+                    let expandToThisLine =
+                        Collecting { End = lineRange.End; Start = range.Start }
+
+                    if lineContent.Trim().Length.Equals(0) then
+                        expandToThisLine
+                    else
+                        go (i + 1) expandToThisLine // in any other case, just move to next line
+                | BeforeMarker -> go (i + 1) BeforeMarker
+
+        match (go 0 BeforeMarker) with
+        // marker was never found
+        | BeforeMarker -> None
+        | Collecting (range) -> Some range

--- a/Marksman/Toc.fs
+++ b/Marksman/Toc.fs
@@ -1,0 +1,33 @@
+module Marksman.Toc
+
+open Marksman.Misc
+open Marksman.Index
+open Marksman.Cst
+
+type Title = string
+type EntryLevel = int
+
+type Entry = { Level: EntryLevel; Title: Title; Link: Slug }
+
+module Entry =
+    let renderLink entry =
+        let offset = String.replicate (entry.Level - 1) " "
+        let slug = entry.Link |> Slug.toString
+        $"{offset}- [{entry.Title}](#{slug})"
+
+    let fromHeading (heading: Heading) : Entry =
+        let slug = Heading.slug heading
+        { Level = heading.level; Link = slug; Title = heading.title.text }
+
+type TableOfContents = { Entries: Entry[] }
+
+module TableOfContents =
+    let mk (index: Index) : TableOfContents option =
+        let headings = index.titles |> Array.map (fun x -> x.data)
+
+        if index.titles.Length.Equals 0 then
+            None
+        else
+            Some { Entries = Array.map Entry.fromHeading headings }
+
+    let render (toc: TableOfContents) = Array.map Entry.renderLink toc.Entries |> String.concat "\n"

--- a/Marksman/Toc.fs
+++ b/Marksman/Toc.fs
@@ -103,6 +103,11 @@ module TableOfContents =
         match (go 0 BeforeMarker) with
         // marker was never found
         | Collected range -> Some range
+        | BeforeMarker -> None
         | other ->
-            logger.error (Log.setMessage $"Got {other} instead")
+            logger.warn (
+                Log.setMessage $"TOC detection failed - end marker was not found"
+                >> Log.addContext "finalState" other
+            )
+
             None

--- a/Tests/DiagTest.fs
+++ b/Tests/DiagTest.fs
@@ -7,10 +7,7 @@ open Marksman.Misc
 open Marksman.Parser
 open Marksman.Workspace
 open Marksman.Diag
-
-let makeFakeDocument (content: string) : Doc =
-    let text = Text.mkText content
-    Doc.mk (PathUri.fromString "memory://fake.md") (PathUri.fromString "memory://") None text
+open Marksman.Helpers
 
 [<Fact>]
 let documentIndex_1 () =

--- a/Tests/Helpers.fs
+++ b/Tests/Helpers.fs
@@ -25,5 +25,5 @@ let makeFakeDocument (content: string) : Doc =
     Doc.mk (PathUri.fromString "memory://fake.md") (PathUri.fromString "memory://") None text
 
 let makeFakeDocumentLines (lines: array<string>) : Doc =
-    let text = Text.mkText (String.concat "\n" lines)
+    let text = Text.mkText (String.concat System.Environment.NewLine lines)
     Doc.mk (PathUri.fromString "memory://fake.md") (PathUri.fromString "memory://") None text

--- a/Tests/Helpers.fs
+++ b/Tests/Helpers.fs
@@ -3,6 +3,7 @@ module Marksman.Helpers
 open System.Runtime.InteropServices
 open Snapper
 open Marksman.Misc
+open Marksman.Workspace
 
 let dummyRoot =
     if RuntimeInformation.IsOSPlatform(OSPlatform.Windows) then
@@ -18,3 +19,11 @@ let checkInlineSnapshot (fmt: 'a -> string) (things: seq<'a>) (snapshot: seq<str
     let lines = Seq.map (fun x -> (fmt x).Lines()) things |> Seq.concat
 
     lines.ShouldMatchInlineSnapshot(snapshot)
+
+let makeFakeDocument (content: string) : Doc =
+    let text = Text.mkText content
+    Doc.mk (PathUri.fromString "memory://fake.md") (PathUri.fromString "memory://") None text
+
+let makeFakeDocumentLines (lines: array<string>) : Doc =
+    let text = Text.mkText (String.concat "\n" lines)
+    Doc.mk (PathUri.fromString "memory://fake.md") (PathUri.fromString "memory://") None text

--- a/Tests/Tests.fsproj
+++ b/Tests/Tests.fsproj
@@ -16,6 +16,7 @@
         <Compile Include="ComplTests.fs" />
         <Compile Include="SematoTests.fs" />
         <Compile Include="WorkspaceTest.fs" />
+        <Compile Include="TocTests.fs" />
         <Compile Include="Program.fs" />
     </ItemGroup>
 

--- a/Tests/TocTests.fs
+++ b/Tests/TocTests.fs
@@ -1,0 +1,89 @@
+module Marksman.TocTests
+
+open Marksman.Index
+open Xunit
+
+open Marksman.Misc
+open Marksman.Parser
+open Marksman.Helpers
+open Marksman.Toc
+
+module DetectToc =
+    [<Fact>]
+    let detectToc_1 () =
+        let doc = makeFakeDocument "# T1\n# T2"
+
+        let titles = TableOfContents.detect doc.text
+
+        Assert.Equal(titles, None)
+
+    [<Fact>]
+    let detectToc_noMarker () =
+        let doc =
+            makeFakeDocumentLines [| "- [T1][#t1]"; " - [T2][#t2]"; ""; ""; "# T1"; "## T2" |]
+
+        let titles = TableOfContents.detect doc.text
+
+        Assert.Equal(titles, None)
+
+    [<Fact>]
+    let detectToc_withMarker () =
+        let doc =
+            makeFakeDocumentLines
+                [| Toc.Marker
+                   "- [T1][#t1]"
+                   " - [T2][#t2]"
+                   ""
+                   ""
+                   "# T1"
+                   "## T2" |]
+
+        let titles = (TableOfContents.detect doc.text).Value
+        let tocText = doc.text.Substring titles
+
+        let expectedTocText =
+            let line num = doc.text.LineContent(num)
+
+            line (0) + "\n" + line (1) + "\n" + line (2)
+
+        Assert.Equal(tocText.TrimEnd(), expectedTocText.TrimEnd())
+        Assert.Equal(5, titles.End.Line)
+        Assert.Equal(0, titles.End.Character)
+
+module CreateToc =
+    [<Fact>]
+    let createToc () =
+        let doc = makeFakeDocumentLines [| "# T1"; "## T2" |]
+
+        let titles = TableOfContents.mk doc.index |> Option.get
+
+        let expected =
+            { Entries =
+                [| { Level = 1; Title = "T1"; Link = Slug.ofString "T1" }
+                   { Level = 2; Title = "T2"; Link = Slug.ofString "T2" } |] }
+
+        Assert.Equal(expected, titles)
+
+module RenderToc =
+    [<Fact>]
+    let createToc () =
+        let doc =
+            makeFakeDocumentLines [| "# T1"; "## T2"; "### T3"; "## T4"; "### T5" |]
+
+        let titles =
+            TableOfContents.mk doc.index |> Option.get |> TableOfContents.render
+
+        let expectedLines =
+            [| Toc.Marker
+               "- [T1](#t1)"
+               " - [T2](#t2)"
+               "  - [T3](#t3)"
+               " - [T4](#t4)"
+               "  - [T5](#t5)"
+               "" // two new lines are important
+               "" 
+            |]
+
+        let expected = String.concat "\n" expectedLines + "\n"
+
+        Assert.Equal(expected, titles)

--- a/Tests/TocTests.fs
+++ b/Tests/TocTests.fs
@@ -8,6 +8,8 @@ open Marksman.Parser
 open Marksman.Helpers
 open Marksman.Toc
 
+open type System.Environment
+
 module DetectToc =
     [<Fact>]
     let detectToc_1 () =
@@ -57,9 +59,7 @@ module CreateToc =
 
         let titles = TableOfContents.mk doc.index |> Option.get
 
-        let expected =
-            { entries =
-                [| Entry.Mk(1, "T1"); Entry.Mk(2, "T2") |] }
+        let expected = { entries = [| Entry.Mk(1, "T1"); Entry.Mk(2, "T2") |] }
 
         Assert.Equal(expected, titles)
 
@@ -79,8 +79,9 @@ module RenderToc =
                "  - [T3](#t3)"
                " - [T4](#t4)"
                "  - [T5](#t5)"
-               Toc.EndMarker |]
+               Toc.EndMarker
+               "" |]
 
-        let expected = String.concat System.Environment.NewLine expectedLines
+        let expected = String.concat NewLine expectedLines
 
         Assert.Equal(expected, titles)


### PR DESCRIPTION
Very basic demonstration of how a "Create TOC" can be implemented.
Note that I don't know F# at all :D 

TODO:

1. Learn F#
2. ~Detect an existing TOC and update it when the code action is invoked (can even put diagnostics on the exact locations saying it's out of date)~
    
    ~This is actually non-trivial if done in a non-invasive manner - only heuristic that can possibly exist is "first block of nothing but links in the document" and it can be easily broken. Can also match those links to a set of headings for some overlap number.~

   ![2022-06-08 21 56 50](https://user-images.githubusercontent.com/1052965/172715905-6e8316c4-15d9-455f-a064-60aa3c0c855c.gif)


