### PR TITLE
Add non-breakable space diagnostic

### DIFF
--- a/Tests/DiagTest.fs
+++ b/Tests/DiagTest.fs
@@ -17,3 +17,17 @@ let documentIndex_1 () =
         Index.titles doc.index |> Array.map (fun x -> x.data.title.text)
 
     Assert.Equal<string>([ "T1"; "T2" ], titles)
+
+[<Fact>]
+let nonBreakingWhitespace () =
+    let nbsp = "\u00a0"
+    let doc = makeFakeDocument $"# T1\n##{nbsp}T2"
+
+    match (checkNonBreakingWhitespace doc) with
+    | [] -> failwith "Expected NonBreakingWhitespace diagnostic"
+    | [ NonBreakableWhitespace range ] ->
+        Assert.Equal(1, range.Start.Line)
+        Assert.Equal(1, range.End.Line)
+
+        Assert.Equal(2, range.Start.Character)
+        Assert.Equal(3, range.End.Character)


### PR DESCRIPTION
SFW version of checking for the sneaky whitespace that breaks headings.

The diagnostic points directly at the first nbsp in the heading

![2022-06-16 11 52 44](https://user-images.githubusercontent.com/1052965/174055295-5abdeb15-4a3e-447e-8469-39fcee7c4beb.gif)