### PR TITLE
Fix incremental text sync

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,3 +93,5 @@ install: publish
 	mkdir -p $${HOME}/.local/bin
 	cp -f Marksman/bin/Release/net6.0/$(RID)/publish/marksman $${HOME}/.local/bin
 endif
+
+.DEFAULT_GOAL := build

--- a/Marksman/Workspace.fs
+++ b/Marksman/Workspace.fs
@@ -91,8 +91,8 @@ module Doc =
             let text = mkText content
 
             Some(mk path root None text)
-        with
-        | :? FileNotFoundException -> None
+        with :? FileNotFoundException ->
+            None
 
     let title (doc: Doc) : option<Node<Heading>> = Index.title doc.index
 

--- a/Tests/TextTests.fs
+++ b/Tests/TextTests.fs
@@ -43,6 +43,23 @@ let applyTextChange_insert_single () =
     Assert.Equal(expected, actual.content)
 
 [<Fact>]
+let applyTextChange_insert_multiple () =
+    let text = Text.mkText "!"
+
+    let actual =
+        Text.applyTextChange
+            [| { Range = Some(Text.mkRange ((0, 1), (0, 1)))
+                 RangeLength = Some 0
+                 Text = " H" }
+               { Range = Some(Text.mkRange ((0, 3), (0, 3)))
+                 RangeLength = Some 0
+                 Text = "i" } |]
+            text
+
+    let expected = "! Hi"
+    Assert.Equal(expected, actual.content)
+
+[<Fact>]
 let applyTextChange_insert_on_empty () =
     let text = Text.mkText ""
 


### PR DESCRIPTION
This fix mostly improves the experience in neovim. This is because neovim does
change batching in a way that was most likely to trigger a text sync issue.

The gist of the problem is that when processing a change notification with
several changes we didn't update the linemap after applying each change. This
led to borked linemap and firing assertions down the line.
