### PR TITLE
fix: Check client's RenameOptions and signal RenameCapabilities from the server

### DIFF
--- a/LanguageServerProtocol/Types.fs
+++ b/LanguageServerProtocol/Types.fs
@@ -708,6 +708,20 @@ type InlayHintClientCapabilities =
     /// Indicates which properties a client can resolve lazily on a inlay
     /// hint.
     ResolveSupport: InlayHintClientCapabilitiesResolveSupport option }
+  
+  type RenameClientCapabilities = {
+      /// Whether rename supports dynamic registration.
+      DynamicRegistration: bool option
+      /// Client supports testing for validity of rename operations before execution.
+      /// @since version 3.12.0
+      PrepareSupport: bool option
+      /// Whether the client honors the change annotations in text edits and resource operations
+      /// returned via the rename request's workspace edit by for example presenting the workspace
+      /// edit in the user interface and asking for confirmation.
+      ///
+      /// @since 3.16.0
+      HonorsChangeAnnotations: bool option
+  }
 
 /// Text document specific client capabilities.
 type TextDocumentClientCapabilities =
@@ -756,7 +770,7 @@ type TextDocumentClientCapabilities =
     DocumentLink: DynamicCapabilities option
 
     /// Capabilities specific to the `textDocument/rename`
-    Rename: DynamicCapabilities option
+    Rename: RenameClientCapabilities option
 
     /// Capabilities for the `textDocument/foldingRange`
     FoldingRange: FoldingRangeCapabilities option
@@ -989,6 +1003,14 @@ type WorkspaceServerCapabilities =
     FileOperations: WorkspaceFileOperationsServerCapabilities option }
   static member Default = { WorkspaceFolders = None; FileOperations = None }
 
+
+/// RenameOptions may only be specified if the client states that it supports prepareSupport in its
+/// initial initialize request.
+type RenameOptions = {
+    /// Renames should be checked and tested before being executed.
+    PrepareProvider: bool option
+}
+
 type ServerCapabilities =
   { /// Defines how text documents are synced. Is either a detailed structure defining each notification or
     /// for backwards compatibility the TextDocumentSyncKind number.
@@ -1040,7 +1062,7 @@ type ServerCapabilities =
     DocumentOnTypeFormattingProvider: DocumentOnTypeFormattingOptions option
 
     /// The server provides rename support.
-    RenameProvider: bool option
+    RenameProvider: U2<bool, RenameOptions> option
 
     /// The server provides document link support.
     DocumentLinkProvider: DocumentLinkOptions option

--- a/Marksman/Server.fs
+++ b/Marksman/Server.fs
@@ -86,6 +86,12 @@ let mkServerCaps (par: InitializeParams) : ServerCapabilities =
     let codeActionOptions =
         { CodeActionKinds = None; ResolveProvider = Some false }
 
+    let renameOptions =
+        if clientDesc.SupportsPrepareRename then
+            { PrepareProvider = Some true } |> U2.Second |> Some
+        else
+            Some(U2.First true)
+
     { ServerCapabilities.Default with
         Workspace = Some workspaceCaps
         TextDocumentSync = Some textSyncCaps
@@ -104,7 +110,7 @@ let mkServerCaps (par: InitializeParams) : ServerCapabilities =
                 { Legend = { TokenTypes = Semato.TokenType.mapping; TokenModifiers = [||] }
                   Range = Some true
                   Full = { Delta = Some false } |> U2.Second |> Some }
-        RenameProvider = Some true }
+        RenameProvider = renameOptions }
 
 let rec headingToSymbolInfo (docUri: PathUri) (h: Node<Heading>) : SymbolInformation[] =
     let name = Heading.name h.data

--- a/Marksman/State.fs
+++ b/Marksman/State.fs
@@ -42,6 +42,14 @@ type ClientDescription =
         }
         |> Option.defaultValue false
 
+    member this.SupportsPrepareRename: bool =
+        monad' {
+            let! textDoc = this.caps.TextDocument
+            let! rename = textDoc.Rename
+            return! rename.PrepareSupport
+        }
+        |> Option.defaultValue false
+
 module ClientDescription =
     let ofParams (par: InitializeParams) : ClientDescription =
         let caps =


### PR DESCRIPTION
PrepareRename needs to be explicitly set in the server's caps based on
client's caps. This wasn't done before due to missing types in
LanguageServerProtocol library and therefore didn't work correctly in
Emacs.