### PR TITLE
fix: Try to fix glob eval for ignores

### DIFF
--- a/Marksman/Marksman.fsproj
+++ b/Marksman/Marksman.fsproj
@@ -32,8 +32,8 @@
         <PackageReference Update="FSharp.Core" Version="6.0.5"/>
         <PackageReference Include="FSharp.SystemCommandLine" Version="0.13.0-beta4"/>
         <PackageReference Include="FSharpPlus" Version="1.2.4"/>
-        <PackageReference Include="Glob" Version="1.1.9"/>
         <PackageReference Include="Markdig" Version="0.30.2"/>
+        <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="6.0.0"/>
         <!--        <PackageReference Include="Ionide.LanguageServerProtocol" Version="0.3.1" />-->
         <PackageReference Include="Serilog" Version="2.11.0"/>
         <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1"/>

--- a/Tests/WorkspaceTest.fs
+++ b/Tests/WorkspaceTest.fs
@@ -1,6 +1,6 @@
 module Marksman.WorkspaceTest
 
-open GlobExpressions
+open System.Runtime.InteropServices
 open Ionide.LanguageServerProtocol.Types
 
 open Xunit
@@ -14,24 +14,48 @@ module FolderTests =
     module ShouldBeIgnoredTests =
         [<Fact>]
         let absGlob_Unix () =
-            let glob = Glob("/node_modules")
-            let root = "/Users/john/notes"
-            let ignored = "/Users/john/notes/node_modules"
-            Folder.shouldBeIgnored [|glob|] root ignored |> Assert.True
-            
-            let notIgnored = "/Users/john/notes/real.md"
-            Folder.shouldBeIgnored [|glob|] root notIgnored |> Assert.False
-            
+            if not (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) then
+                let glob = Folder.buildGlobs ([| "/node_modules" |])
+                let root = "/Users/john/notes"
+                let ignored = "/Users/john/notes/node_modules"
+                Folder.shouldBeIgnored glob root ignored |> Assert.True
+
+                let notIgnored = "/Users/john/notes/real.md"
+                Folder.shouldBeIgnored glob root notIgnored |> Assert.False
+
+        [<Fact>]
+        let relGlob_Unix () =
+            if not (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) then
+                let glob = Folder.buildGlobs ([| "a/b" |])
+                let root = "/Users/john/notes"
+                let ignored = "/Users/john/notes/a/b"
+                Folder.shouldBeIgnored glob root ignored |> Assert.True
+
+                let notIgnored = "/Users/john/notes/a/real.md"
+                Folder.shouldBeIgnored glob root notIgnored |> Assert.False
+
         [<Fact>]
         let absGlob_Win () =
-            let glob = Glob("/node_modules")
-            let root = "C:\\notes"
-            let ignored = "C:\\notes\\node_modules"
-            Folder.shouldBeIgnored [|glob|] root ignored |> Assert.True
-            
-            let notIgnored = "C:\\notes\\real.md"
-            Folder.shouldBeIgnored [|glob|] root notIgnored |> Assert.False
-        
+            if RuntimeInformation.IsOSPlatform(OSPlatform.Windows) then
+                let glob = Folder.buildGlobs ([| "/node_modules" |])
+                let root = "C:\\notes"
+                let ignored = "C:\\notes\\node_modules"
+                Folder.shouldBeIgnored glob root ignored |> Assert.True
+
+                let notIgnored = "C:\\notes\\real.md"
+                Folder.shouldBeIgnored glob root notIgnored |> Assert.False
+
+        [<Fact>]
+        let relGlob_Win () =
+            if RuntimeInformation.IsOSPlatform(OSPlatform.Windows) then
+                let glob = Folder.buildGlobs ([| "a/b" |])
+                let root = "C:\\notes"
+                let ignored = "C:\\notes\\a\\b"
+                Folder.shouldBeIgnored glob root ignored |> Assert.True
+
+                let notIgnored = "C:\\notes\\a\\real.md"
+                Folder.shouldBeIgnored glob root notIgnored |> Assert.False
+
 
 module DocTest =
     [<Fact>]


### PR DESCRIPTION
Neither Glob nor Dotnet.Glob libraries worked in a reasonable way (e.g. following git's semantics for .gitignore).
Here I try to use Microsoft's extension library for filesystem globbing. Preliminary testing results are encouraging. The problem is that it uses system dependent path handling, which means tests for Windows fail on Unix and vice-versa :(