### PR TITLE
diag/fix: Re-send diagnostics when the document is reopened

### DIFF
--- a/Marksman/Workspace.fs
+++ b/Marksman/Workspace.fs
@@ -119,6 +119,8 @@ module Doc =
 
     let linkAtPos (pos: Position) (doc: Doc) : option<Element> = Index.linkAtPos pos doc.index
 
+    let version (doc: Doc) : option<int> = doc.version
+
 type Folder = { name: string; root: PathUri; docs: Map<PathUri, Doc> }
 
 module Folder =


### PR DESCRIPTION
Previously, the logic was simple: if during state update the diagnostics
for a file didn't change there's no need to re-send it.

This is true, when the file is closed/re-opened: no change, no need to
send diagnostics. However, some (all?) editors drop diagnostics when a
file gets closed.

Now the server checks for this case too and re-sends the diagnotics when
needed.

Resolves #62.
