### PR TITLE
ca/toc: Ignore whitespace when checking if TOC is up-to-date

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "fantomas": {
-      "version": "5.0.0-beta-005",
+      "version": "5.0.0-beta-009",
       "commands": [
         "fantomas"
       ]

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,9 @@
+[*]
+end_of_line=lf
+
 [*.{fs,fsx}]
 indent_size=4
 max_line_length=100
-end_of_line=lf
 insert_final_newline=true
 fsharp_max_if_then_else_short_width=70
 fsharp_max_infix_operator_expression=70

--- a/Marksman/CodeActions.fs
+++ b/Marksman/CodeActions.fs
@@ -26,12 +26,13 @@ let tableOfContents (document: Doc) : DocumentAction option =
         let rendered = TableOfContents.render toc
         let existingRange = TableOfContents.detect document.text
 
-        let existingText =
+        let isSame =
             existingRange
             |> Option.map document.text.Substring
-            |> Option.map (fun x -> x.Trim())
+            |> Option.map (TableOfContents.isSame rendered)
+            |> Option.defaultValue false
 
-        if existingText = Some rendered then
+        if isSame then
             None
         else
             let name =

--- a/Marksman/Misc.fs
+++ b/Marksman/Misc.fs
@@ -10,6 +10,8 @@ let flip (f: 'a -> 'b -> 'c) : 'b -> 'a -> 'c = fun b a -> f a b
 
 let lineEndings = [| "\r\n"; "\n" |]
 
+let concatLines (lines: array<string>) : string = String.concat Environment.NewLine lines
+
 type String with
 
     member this.Lines() : array<string> = this.Split(lineEndings, StringSplitOptions.None)
@@ -83,6 +85,15 @@ type String with
             this.Substring(prefix.Length)
         else
             this
+
+    member this.TrimSuffix(suffix: string) : string =
+        if this.EndsWith(suffix) then
+            this.Substring(0, this.Length - suffix.Length)
+        else
+            this
+
+    member this.TrimBoth(prefix: string, suffix: string) : string =
+        this.TrimPrefix(prefix).TrimSuffix(suffix)
 
 type Slug = Slug of string
 

--- a/Marksman/Server.fs
+++ b/Marksman/Server.fs
@@ -490,12 +490,22 @@ type MarksmanServer(client: MarksmanClient) =
         let initResult =
             { InitializeResult.Default with Capabilities = serverCaps }
 
+        logger.debug (
+            Log.setMessage
+                "Finished workspace initialization. Waiting for the `initialized` notification from the client."
+        )
+
         AsyncLspResult.success initResult
 
 
     override this.Initialized(_: InitializedParams) =
         withStateExclusive
         <| fun state ->
+            logger.debug (
+                Log.setMessage
+                    "Received `initialized` notification from the client. Setting up background services."
+            )
+
             let diagHook = queueDiagnosticsUpdate diagnosticsManager
             let mutable newHooks = [ { name = "diag"; fn = diagHook } ]
 
@@ -511,6 +521,8 @@ type MarksmanServer(client: MarksmanClient) =
                     Log.setMessage
                         "Client doesn't support status notifications. Agent won't be initialized."
                 )
+
+            logger.debug (Log.setMessage "Initialization complete.")
 
             Mutation.hooks newHooks
 

--- a/Marksman/Toc.fs
+++ b/Marksman/Toc.fs
@@ -78,7 +78,7 @@ module TableOfContents =
 
         let lines = Array.concat [| startMarkerLines; tocLinks; endMarkerLines |]
 
-        String.concat NewLine lines
+        concatLines lines
 
     type State =
         | BeforeMarker
@@ -128,3 +128,15 @@ module TableOfContents =
             )
 
             None
+
+
+    let isSame (tocA: string) (tocB: string) =
+        // Have to do this line-by-line comparison to make sure that things work as expected both
+        // on Unix and Windows and when mixed line-endings are used.
+        let contentA = tocA.TrimBoth(StartMarker, EndMarker).Trim().Lines()
+        let contentB = tocB.TrimBoth(StartMarker, EndMarker).Trim().Lines()
+
+        if contentA.Length <> contentB.Length then
+            false
+        else
+            Array.forall2 (=) contentA contentB

--- a/Tests/Helpers.fs
+++ b/Tests/Helpers.fs
@@ -4,11 +4,7 @@ open System.Runtime.InteropServices
 open Snapper
 open Marksman.Misc
 open Marksman.Workspace
-open Marksman.Text
-open Ionide.LanguageServerProtocol.Types
 open Marksman.CodeActions
-
-open type System.Environment
 
 let pathToUri path = $"file://{path}"
 
@@ -33,11 +29,11 @@ let applyDocumentAction (doc: Doc) (action: DocumentAction): string =
     before + action.newText + after
 
 let stripMargin (str: string) = 
-    let lines = str.Split NewLine
+    let lines = str.Lines()
     let modified = lines |> Array.map(fun line -> 
         System.Text.RegularExpressions.Regex.Replace(line, "^[\s]*\|", "")
     )
-    String.concat NewLine modified
+    String.concat System.Environment.NewLine modified
 
 let stripMarginTrim (str: string) = 
     stripMargin (str.Trim())

--- a/Tests/Helpers.fs
+++ b/Tests/Helpers.fs
@@ -23,20 +23,19 @@ let checkInlineSnapshot (fmt: 'a -> string) (things: seq<'a>) (snapshot: seq<str
 
     lines.ShouldMatchInlineSnapshot(snapshot)
 
-let applyDocumentAction (doc: Doc) (action: DocumentAction): string =
+let applyDocumentAction (doc: Doc) (action: DocumentAction) : string =
     let (before, after) = doc.text.Cutout(action.edit)
 
     before + action.newText + after
 
-let stripMargin (str: string) = 
+let stripMargin (str: string) =
     let lines = str.Lines()
-    let modified = lines |> Array.map(fun line -> 
-        System.Text.RegularExpressions.Regex.Replace(line, "^[\s]*\|", "")
-    )
-    String.concat System.Environment.NewLine modified
 
-let stripMarginTrim (str: string) = 
-    stripMargin (str.Trim())
+    lines
+    |> Array.map (fun line -> System.Text.RegularExpressions.Regex.Replace(line, "^[\s]*\|", ""))
+    |> concatLines
+
+let stripMarginTrim (str: string) = stripMargin (str.Trim())
 
 type FakeDoc =
     class
@@ -51,7 +50,7 @@ type FakeDoc =
 
         static member Mk(contentLines: array<string>, ?path: string) : Doc =
             let content = String.concat System.Environment.NewLine contentLines
-            FakeDoc.Mk (content, ?path = path)
+            FakeDoc.Mk(content, ?path = path)
     end
 
 type FakeFolder =

--- a/Tests/MiscTests.fs
+++ b/Tests/MiscTests.fs
@@ -78,6 +78,14 @@ module StringExtensionsTests =
     let abspath_urlencode_5 () =
         Assert.Equal("/folder%20name/file%20name.md", "folder name/file name.md".AbsPathUrlEncode())
         Assert.Equal("/folder%20name/file%20name.md".AbsPathUrlEncodedToRelPath(), "folder name/file name.md")
+        
+    [<Fact>]
+    let trimSuffix_1 () =
+        Assert.Equal("foo", "foobar".TrimSuffix("bar"))
+        
+    [<Fact>]
+    let trimSuffix_2 () =
+        Assert.Equal("foobar", "foobar".TrimSuffix("baz"))
     
 module PathUriTests =
     [<Fact>]

--- a/Tests/TocTests.fs
+++ b/Tests/TocTests.fs
@@ -327,3 +327,21 @@ module DocumentEdit =
         let action = CodeActions.tableOfContents doc
 
         Assert.Equal(None, action)
+        
+    [<Fact>]
+    let upToDate_whitespace_noUpdate () =
+        let text =
+            stripMarginTrim
+                $"
+                |{StartMarker}
+                |
+                |- [T1](#t1)
+                |{EndMarker}
+                |
+                |# T1"
+
+        let doc = FakeDoc.Mk text
+
+        let action = CodeActions.tableOfContents doc
+
+        Assert.Equal(None, action)


### PR DESCRIPTION
- test: Make stripMargin correctly handle mixed line endings
- misc: Bump fantomas version
- ca/toc: Ignore whitespace when checking if TOC is up-to-date
