### PR TITLE
WIP: Support single-file mode

### DIFF
--- a/Marksman/CodeActions.fs
+++ b/Marksman/CodeActions.fs
@@ -20,15 +20,15 @@ let documentEdit range text documentUri : WorkspaceEdit =
 
     { Changes = Some workspaceChanges; DocumentChanges = None }
 
-let tableOfContents (document: Doc) : DocumentAction option =
-    match TableOfContents.mk document.index with
+let tableOfContents (doc: Doc) : DocumentAction option =
+    match TableOfContents.mk (Doc.index doc) with
     | Some toc ->
         let rendered = TableOfContents.render toc
-        let existingRange = TableOfContents.detect document.text
+        let existingRange = TableOfContents.detect (Doc.text doc)
 
         let isSame =
             existingRange
-            |> Option.map document.text.Substring
+            |> Option.map (Doc.text doc).Substring
             |> Option.map (TableOfContents.isSame rendered)
             |> Option.defaultValue false
 
@@ -43,7 +43,7 @@ let tableOfContents (document: Doc) : DocumentAction option =
             let insertionPoint =
                 match existingRange with
                 | Some range -> Replacing range
-                | None -> TableOfContents.insertionPoint document
+                | None -> TableOfContents.insertionPoint doc
 
             logger.trace (
                 Log.setMessage "Determining table of contents insertion point"
@@ -52,7 +52,7 @@ let tableOfContents (document: Doc) : DocumentAction option =
                 >> Log.addContext "text" rendered
             )
 
-            let isEmpty lineNumber = document.text.LineContent(lineNumber).IsWhitespace()
+            let isEmpty lineNumber = (Doc.text doc).LineContent(lineNumber).IsWhitespace()
 
             let emptyLine = NewLine + NewLine
             let lineBreak = NewLine
@@ -81,7 +81,7 @@ let tableOfContents (document: Doc) : DocumentAction option =
                     let newRange = Range.Mk(lineAfterLast, 0, lineAfterLast, 0)
 
                     let before = if isEmpty range.End.Line then "" else lineBreak
-                    let after = if isEmpty (lineAfterLast) then lineBreak else emptyLine
+                    let after = if isEmpty lineAfterLast then lineBreak else emptyLine
 
                     newRange, before, after
 

--- a/Marksman/Diag.fs
+++ b/Marksman/Diag.fs
@@ -170,12 +170,12 @@ module FolderDiag =
             uri, lspDiags)
         |> Array.ofSeq
 
-type WorkspaceDiag = Map<PathUri, FolderDiag>
+type WorkspaceDiag = Map<FolderId, FolderDiag>
 
 module WorkspaceDiag =
     let mk (ws: Workspace) : WorkspaceDiag =
         Workspace.folders ws
-        |> Seq.map (fun folder -> (Folder.keyPath folder), FolderDiag.mk folder)
+        |> Seq.map (fun folder -> (Folder.id folder), FolderDiag.mk folder)
         |> Map.ofSeq
 
     let empty = Map.empty

--- a/Marksman/Diag.fs
+++ b/Marksman/Diag.fs
@@ -26,9 +26,9 @@ let checkNonBreakingWhitespace (doc: Doc) =
 
     let headings = [ 1..7 ] |> List.map (fun n -> (String.replicate n "#"))
 
-    [ 0 .. doc.text.lineMap.NumLines ]
+    [ 0 .. (Doc.text doc).lineMap.NumLines ]
     |> List.collect (fun x ->
-        let line = doc.text.LineContent x
+        let line = (Doc.text doc).LineContent x
 
         let headingLike =
             List.tryFind (fun (h: string) -> line.StartsWith(h + nonBreakingWhitespace)) headings
@@ -62,7 +62,7 @@ let checkLink (folder: Folder) (doc: Doc) (link: Element) : seq<Entry> =
             [ AmbiguousLink(link, uref, refs) ]
 
 let checkLinks (folder: Folder) (doc: Doc) : seq<Entry> =
-    let links = Index.links doc.index
+    let links = Doc.index >> Index.links <| doc
     links |> Seq.collect (checkLink folder doc)
 
 let checkFolder (folder: Folder) : seq<PathUri * list<Entry>> =
@@ -75,7 +75,7 @@ let checkFolder (folder: Folder) : seq<PathUri * list<Entry>> =
                 }
                 |> List.ofSeq
 
-            doc.path, docDiag
+            Doc.path doc, docDiag
     }
 
 let refToHuman (ref: Dest) : string =
@@ -175,7 +175,7 @@ type WorkspaceDiag = Map<PathUri, FolderDiag>
 module WorkspaceDiag =
     let mk (ws: Workspace) : WorkspaceDiag =
         Workspace.folders ws
-        |> Seq.map (fun folder -> folder.root, FolderDiag.mk folder)
+        |> Seq.map (fun folder -> (Folder.keyPath folder), FolderDiag.mk folder)
         |> Map.ofSeq
 
     let empty = Map.empty

--- a/Marksman/Diag.fs
+++ b/Marksman/Diag.fs
@@ -42,6 +42,13 @@ let checkNonBreakingWhitespace (doc: Doc) =
 
             [ NonBreakableWhitespace(whitespaceRange) ])
 
+let isCrossFileLink uref =
+    match uref with
+    | Uref.Doc _ -> true
+    | Uref.Heading(doc = Some _) -> true
+    | Uref.Heading(doc = None) -> false
+    | Uref.LinkDef _ -> false
+
 let checkLink (folder: Folder) (doc: Doc) (link: Element) : seq<Entry> =
     let uref = Uref.ofElement link
 
@@ -50,7 +57,9 @@ let checkLink (folder: Folder) (doc: Doc) (link: Element) : seq<Entry> =
     | Some uref ->
         let refs = Dest.tryResolveUref uref doc folder |> Array.ofSeq
 
-        if refs.Length = 1 then
+        if Folder.isSingleFile folder && isCrossFileLink uref then
+            []
+        else if refs.Length = 1 then
             []
         else if refs.Length = 0 then
             match link with

--- a/Marksman/Marksman.fsproj
+++ b/Marksman/Marksman.fsproj
@@ -9,7 +9,7 @@
     </PropertyGroup>
     <Target Name="Version" BeforeTargets="BeforeBuild">
         <Exec Command="git describe --always --dirty" ConsoleToMSBuild="true">
-            <Output TaskParameter="ConsoleOutput" PropertyName="VersionString" />
+            <Output TaskParameter="ConsoleOutput" PropertyName="VersionString"/>
         </Exec>
         <PropertyGroup>
             <VersionSuffix>$(VersionString)</VersionSuffix>
@@ -20,38 +20,39 @@
         <PropertyGroup>
             <LintCommand>dotnet fsharplint -f msbuild lint --lint-config $(MSBuildProjectDirectory)/../fsharplint.json $(MSBuildProjectFullPath)</LintCommand>
         </PropertyGroup>
-        <Exec Command="$(LintCommand)" ConsoleToMSBuild="true" IgnoreExitCode="true" />
+        <Exec Command="$(LintCommand)" ConsoleToMSBuild="true" IgnoreExitCode="true"/>
     </Target>
     <ItemGroup>
-        <Compile Include="Misc.fs" />
-        <Compile Include="Text.fs" />
-        <Compile Include="Cst.fs" />
-        <Compile Include="Parser.fs" />
-        <Compile Include="Index.fs" />
-        <Compile Include="Workspace.fs" />
-        <Compile Include="Semato.fs" />
-        <Compile Include="Refs.fs" />
-        <Compile Include="Diag.fs" />
-        <Compile Include="State.fs" />
-        <Compile Include="Toc.fs" />
-        <Compile Include="CodeActions.fs" />
-        <Compile Include="Compl.fs" />
-        <Compile Include="Refactor.fs" />
-        <Compile Include="Server.fs" />
-        <Compile Include="Program.fs" />
+        <Compile Include="Misc.fs"/>
+        <Compile Include="Text.fs"/>
+        <Compile Include="Cst.fs"/>
+        <Compile Include="Parser.fs"/>
+        <Compile Include="Index.fs"/>
+        <Compile Include="Workspace.fsi"/>
+        <Compile Include="Workspace.fs"/>
+        <Compile Include="Semato.fs"/>
+        <Compile Include="Refs.fs"/>
+        <Compile Include="Diag.fs"/>
+        <Compile Include="State.fs"/>
+        <Compile Include="Toc.fs"/>
+        <Compile Include="CodeActions.fs"/>
+        <Compile Include="Compl.fs"/>
+        <Compile Include="Refactor.fs"/>
+        <Compile Include="Server.fs"/>
+        <Compile Include="Program.fs"/>
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Update="FSharp.Core" Version="6.0.5" />
-        <PackageReference Include="FSharp.SystemCommandLine" Version="0.13.0-beta4" />
-        <PackageReference Include="FSharpPlus" Version="1.2.4" />
-        <PackageReference Include="Markdig" Version="0.30.2" />
-        <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="6.0.0" />
+        <PackageReference Update="FSharp.Core" Version="6.0.5"/>
+        <PackageReference Include="FSharp.SystemCommandLine" Version="0.13.0-beta4"/>
+        <PackageReference Include="FSharpPlus" Version="1.2.4"/>
+        <PackageReference Include="Markdig" Version="0.30.2"/>
+        <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="6.0.0"/>
         <!--        <PackageReference Include="Ionide.LanguageServerProtocol" Version="0.3.1" />-->
-        <PackageReference Include="Serilog" Version="2.11.0" />
-        <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
+        <PackageReference Include="Serilog" Version="2.11.0"/>
+        <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="..\LanguageServerProtocol\LanguageServerProtocol.fsproj" />
-        <ProjectReference Include="..\MarkdigPatches\MarkdigPatches.csproj" />
+        <ProjectReference Include="..\LanguageServerProtocol\LanguageServerProtocol.fsproj"/>
+        <ProjectReference Include="..\MarkdigPatches\MarkdigPatches.csproj"/>
     </ItemGroup>
 </Project>

--- a/Marksman/Misc.fs
+++ b/Marksman/Misc.fs
@@ -175,7 +175,7 @@ let localPathToUriString (filePath: string) : string =
         "file:///" + uri.ToString().TrimStart('/')
 
 module PathUri =
-    let fromString (str: string) : PathUri =
+    let ofString (str: string) : PathUri =
         let unescaped = Uri.UnescapeDataString(str)
         let uri = Uri(unescaped)
         let localPath = uri.LocalPath

--- a/Marksman/Misc.fs
+++ b/Marksman/Misc.fs
@@ -3,6 +3,7 @@ module Marksman.Misc
 open System
 open System.Text
 open Ionide.LanguageServerProtocol.Types
+open Microsoft.Extensions.FileSystemGlobbing
 
 let todo what = failwith $"{what} not implemented"
 
@@ -197,6 +198,20 @@ module PathUri =
                 localPathToUriString localPath
 
         { uri = escapedUri; localPath = localPath }
+
+let buildGlobs (patterns: array<string>) : Matcher =
+    let matcher = Matcher().AddInclude("**")
+
+    matcher.AddExcludePatterns([| ".git"; ".hg" |])
+    matcher.AddExcludePatterns(patterns)
+    matcher
+
+let shouldBeIgnored (ignores: Matcher) (root: string) (fullFilePath: string) : bool =
+    let shouldIgnore = ignores.Match(root, fullFilePath).HasMatches |> not
+    shouldIgnore
+
+let shouldBeIgnoredByAny (ignoreFns: list<string -> bool>) (fullFilePath: string) : bool =
+    ignoreFns |> List.exists (fun f -> f fullFilePath)
 
 
 type Position with

--- a/Marksman/State.fs
+++ b/Marksman/State.fs
@@ -112,12 +112,14 @@ module State =
             >> Log.addContext "numRemoved" removed.Length
         )
 
-        let removedUris = removed |> Array.map (fun f -> PathUri.fromString f.Uri)
+        let removedUris =
+            removed
+            |> Array.map (fun f -> PathUri.ofString f.Uri |> FolderId.ofPath)
 
         let addedFolders =
             seq {
                 for f in added do
-                    let rootUri = PathUri.fromString f.Uri
+                    let rootUri = RootPath.ofString f.Uri
 
                     let folder = Folder.tryLoad f.Name rootUri
 
@@ -138,6 +140,6 @@ module State =
         let newWs = Workspace.withFolder newFolder state.workspace
         { state with workspace = newWs; revision = state.revision + 1 }
 
-    let removeFolder (keyPath: PathUri) (state: State) : State =
+    let removeFolder (keyPath: FolderId) (state: State) : State =
         let newWs = Workspace.withoutFolder keyPath state.workspace
         { state with workspace = newWs; revision = state.revision + 1 }

--- a/Marksman/Toc.fs
+++ b/Marksman/Toc.fs
@@ -1,13 +1,13 @@
 module Marksman.Toc
 
+open Ionide.LanguageServerProtocol.Types
+open Ionide.LanguageServerProtocol.Logging
+
 open Marksman.Misc
 open Marksman.Index
 open Marksman.Cst
 open Marksman.Text
-open Ionide.LanguageServerProtocol.Types
-open Ionide.LanguageServerProtocol.Logging
-
-open type System.Environment
+open Marksman.Workspace
 
 [<Literal>]
 let StartMarker = """<!--toc:start-->"""
@@ -55,12 +55,14 @@ module TableOfContents =
         else
             Some { entries = Array.map Entry.fromHeading headings }
 
-    let insertionPoint (doc: Workspace.Doc) : InsertionPoint =
-        match (Array.toList doc.index.titles) with
+    let insertionPoint (doc: Doc) : InsertionPoint =
+        let index = Doc.index doc
+
+        match (Array.toList index.titles) with
         // if there's only a single title
         | [ singleTitle ] -> After singleTitle.range
         | _ ->
-            match doc.index.yamlFrontMatter with
+            match index.yamlFrontMatter with
             | None -> DocumentBeginning
             | Some yml -> After yml.range
 
@@ -107,7 +109,7 @@ module TableOfContents =
                     else
                         go (i + 1) BeforeMarker
                 // if we are in collecting mode, just expand the selection
-                | Collecting (range) ->
+                | Collecting range ->
                     let toThisLine = expandToThisLine range
 
                     if isEndMarker then

--- a/Marksman/Workspace.fs
+++ b/Marksman/Workspace.fs
@@ -149,6 +149,11 @@ module Folder =
 
     let singleFile doc = SingleFile doc
 
+    let isSingleFile =
+        function
+        | SingleFile _ -> true
+        | MultiFile _ -> false
+
     let multiFile name root docs = MultiFile(name, root, docs)
 
     let docs: Folder -> seq<Doc> =

--- a/Marksman/Workspace.fsi
+++ b/Marksman/Workspace.fsi
@@ -1,0 +1,65 @@
+module Marksman.Workspace
+
+open Ionide.LanguageServerProtocol.Types
+
+open Marksman.Misc
+open Marksman.Cst
+open Marksman.Index
+open Marksman.Text
+
+type Doc
+
+module Doc =
+    val rootPath: Doc -> PathUri
+    val path: Doc -> PathUri
+    val pathFromRoot: Doc -> string
+    val text: Doc -> Text
+    val version: Doc -> option<int>
+    val cst: Doc -> Cst
+    val title: Doc -> option<Node<Heading>>
+    val name: Doc -> string
+    val index: Doc -> Index
+    val uri: Doc -> DocumentUri
+
+    val tryLoad: root: PathUri -> path: PathUri -> option<Doc>
+
+    val mk: path: PathUri -> rootPath: PathUri -> version: option<int> -> Text -> Doc
+    val fromLsp: root: PathUri -> TextDocumentItem -> Doc
+    val applyLspChange: DidChangeTextDocumentParams -> Doc -> Doc
+
+type Folder
+
+module Folder =
+    val keyPath: Folder -> PathUri
+    val rootPath: Folder -> PathUri
+
+    val docs: Folder -> seq<Doc>
+    val docCount: Folder -> int
+
+    val tryLoad: name: string -> root: PathUri -> option<Folder>
+
+    val singleFile: Doc -> Folder
+    val multiFile: name: string -> root: PathUri -> docs: Map<PathUri, Doc> -> Folder
+
+    val withDoc: Doc -> Folder -> Folder
+    val withoutDoc: PathUri -> Folder -> option<Folder>
+    val closeDoc: PathUri -> Folder -> option<Folder>
+
+    val tryFindDocByPath: PathUri -> Folder -> option<Doc>
+    val tryFindDocByUrl: string -> Folder -> option<Doc>
+    val filterDocsBySlug: Slug -> Folder -> seq<Doc>
+
+type Workspace
+
+module Workspace =
+    val folders: Workspace -> seq<Folder>
+    val docCount: Workspace -> int
+
+    val withFolder: Folder -> Workspace -> Workspace
+    val withFolders: seq<Folder> -> Workspace -> Workspace
+    val ofFolders: seq<Folder> -> Workspace
+
+    val withoutFolder: PathUri -> Workspace -> Workspace
+    val withoutFolders: seq<PathUri> -> Workspace -> Workspace
+
+    val tryFindFolderEnclosing: PathUri -> Workspace -> option<Folder>

--- a/Marksman/Workspace.fsi
+++ b/Marksman/Workspace.fsi
@@ -7,10 +7,26 @@ open Marksman.Cst
 open Marksman.Index
 open Marksman.Text
 
+[<Sealed>]
+type FolderId =
+    interface System.IComparable
+
+module FolderId =
+    val ofPath: PathUri -> FolderId
+
+[<Sealed>]
+type RootPath =
+    interface System.IComparable
+
+module RootPath =
+    val ofPath: PathUri -> RootPath
+    val ofString: string -> RootPath
+    val path: RootPath -> PathUri
+
 type Doc
 
 module Doc =
-    val rootPath: Doc -> PathUri
+    val rootPath: Doc -> RootPath
     val path: Doc -> PathUri
     val pathFromRoot: Doc -> string
     val text: Doc -> Text
@@ -21,25 +37,25 @@ module Doc =
     val index: Doc -> Index
     val uri: Doc -> DocumentUri
 
-    val tryLoad: root: PathUri -> path: PathUri -> option<Doc>
+    val tryLoad: root: RootPath -> path: PathUri -> option<Doc>
 
-    val mk: path: PathUri -> rootPath: PathUri -> version: option<int> -> Text -> Doc
-    val fromLsp: root: PathUri -> TextDocumentItem -> Doc
+    val mk: path: PathUri -> rootPath: RootPath -> version: option<int> -> Text -> Doc
+    val fromLsp: root: RootPath -> TextDocumentItem -> Doc
     val applyLspChange: DidChangeTextDocumentParams -> Doc -> Doc
 
 type Folder
 
 module Folder =
-    val keyPath: Folder -> PathUri
-    val rootPath: Folder -> PathUri
+    val id: Folder -> FolderId
+    val rootPath: Folder -> RootPath
 
     val docs: Folder -> seq<Doc>
     val docCount: Folder -> int
 
-    val tryLoad: name: string -> root: PathUri -> option<Folder>
+    val tryLoad: name: string -> root: RootPath -> option<Folder>
 
     val singleFile: Doc -> Folder
-    val multiFile: name: string -> root: PathUri -> docs: Map<PathUri, Doc> -> Folder
+    val multiFile: name: string -> root: RootPath -> docs: Map<PathUri, Doc> -> Folder
 
     val withDoc: Doc -> Folder -> Folder
     val withoutDoc: PathUri -> Folder -> option<Folder>
@@ -59,7 +75,7 @@ module Workspace =
     val withFolders: seq<Folder> -> Workspace -> Workspace
     val ofFolders: seq<Folder> -> Workspace
 
-    val withoutFolder: PathUri -> Workspace -> Workspace
-    val withoutFolders: seq<PathUri> -> Workspace -> Workspace
+    val withoutFolder: FolderId -> Workspace -> Workspace
+    val withoutFolders: seq<FolderId> -> Workspace -> Workspace
 
     val tryFindFolderEnclosing: PathUri -> Workspace -> option<Folder>

--- a/Marksman/Workspace.fsi
+++ b/Marksman/Workspace.fsi
@@ -56,6 +56,7 @@ module Folder =
 
     val singleFile: Doc -> Folder
     val multiFile: name: string -> root: RootPath -> docs: Map<PathUri, Doc> -> Folder
+    val isSingleFile: Folder -> bool
 
     val withDoc: Doc -> Folder -> Folder
     val withoutDoc: PathUri -> Folder -> option<Folder>

--- a/README.md
+++ b/README.md
@@ -158,20 +158,27 @@ Marksman by default reads ignore globs from `.gitignore`, `.hgignore`, and
 Marksman will search for and read ignore files in all sub-folders of the
 workspace. similarly to what Git does.
 
-### Workspace folders and project roots
+### Workspace folders, project roots, and single-file mode
 
 The LSP specification is designed to work with projects rather than individual
-files<sup>[4](#fn4)</sup>. How a root folder of a project is found varies
-between editors, but usually it's either
-1. a root of the version control system (applicable to all languages),
-2. a folder with `.marksman.toml` marker file (specific to Marksman integrations).
+files<sup>[4](#fn4)</sup>. Marksman has a custom **single-file mode** that
+provides a *subset* of language features for markdown files open outside of any
+project. This works well for small one-off edits or when opening random
+markdown files. However, when you have several interconnected documents do
+consider setting up a project folder for them for an improved experience. 
 
-Therefore, in case Marksman doesn't provide Markdown language assist for your
-files and you don't understand why, you can either:
+How a folder (aka project, aka root) is found varies between editors, but
+usually it's either
+1. a root of a VCS repository (applicable to all languages),
+2. a folder with `.marksman.toml` marker file (specific to Marksman
+   integrations).
+
+When Marksman doesn't provide cross-file language assist for your files and you
+don't understand why, you can either:
 1. check your project into version control, or
 2. create a `.marksman.toml` at the root folder of your project, or
-3. refer to your editor/LSP client documentation regarding how project root is
-   defined.
+3. refer to your editor/LSP client documentation regarding how a project root
+   is defined.
 
 ## Where's `zeta-note` and where's Rust?
 

--- a/Tests/ComplTests.fs
+++ b/Tests/ComplTests.fs
@@ -292,7 +292,7 @@ module Candidates =
                    "#B"
                    "## H2"
                    "[](/doc%202.md#)" |] // 6
-                //  012345678901234567890
+        //  012345678901234567890
         )
 
     let doc2 =
@@ -302,15 +302,15 @@ module Candidates =
 
     [<Fact>]
     let noDupsOnAchor_intraFile () =
-        let cand = findCandidates (Position.Mk(1, 3)) doc1.path folder
+        let cand = findCandidates (Position.Mk(1, 3)) (Doc.path doc1) folder
         checkSnapshot cand
 
     [<Fact>]
     let noDupsOnAchor_crossFile () =
-        let cand = findCandidates (Position.Mk(1, 3)) doc1.path folder
+        let cand = findCandidates (Position.Mk(1, 3)) (Doc.path doc1) folder
         checkSnapshot cand
-        
+
     [<Fact>]
     let fileWithSpaces_anchor () =
-        let cand = findCandidates (Position.Mk(6, 15)) doc1.path folder
+        let cand = findCandidates (Position.Mk(6, 15)) (Doc.path doc1) folder
         checkSnapshot cand

--- a/Tests/DiagTest.fs
+++ b/Tests/DiagTest.fs
@@ -26,7 +26,8 @@ let documentIndex_1 () =
     let doc = FakeDoc.Mk "# T1\n# T2"
 
     let titles =
-        Index.titles doc.index |> Array.map (fun x -> x.data.title.text)
+        Doc.index >> Index.titles <| doc
+        |> Array.map (fun x -> x.data.title.text)
 
     Assert.Equal<string>([ "T1"; "T2" ], titles)
 
@@ -64,11 +65,17 @@ let noDiagOnRealUrls () =
         [ "fake.md", "Link to non-existent document at 'www.bad.md'" ],
         diag
     )
-    
+
 [<Fact>]
 let noDiagOnNonMarkdownFiles () =
     let doc =
-        FakeDoc.Mk([| "# H1"; "## H2"; "[](bad.md)"; "[](another%20bad.md)"; "[](good/folder)" |])
+        FakeDoc.Mk(
+            [| "# H1"
+               "## H2"
+               "[](bad.md)"
+               "[](another%20bad.md)"
+               "[](good/folder)" |]
+        )
 
     let folder = FakeFolder.Mk([ doc ])
     let diag = checkFolder folder |> diagToHuman

--- a/Tests/DiagTest.fs
+++ b/Tests/DiagTest.fs
@@ -85,3 +85,20 @@ let noDiagOnNonMarkdownFiles () =
           "fake.md", "Link to non-existent document at 'another%20bad.md'" ],
         diag
     )
+
+[<Fact>]
+let noCrossFileDiagOnSingleFileFolders () =
+    let doc =
+        FakeDoc.Mk(
+            [| "[](bad.md)" //
+               "[[another-bad]]"
+               "[bad-ref][bad-ref]" |]
+        )
+
+    let folder = Folder.singleFile doc
+    let diag = checkFolder folder |> diagToHuman
+
+    Assert.Equal<string * string>(
+        [ "fake.md", "Link to non-existent link definition with the label 'bad-ref'" ],
+        diag
+    )

--- a/Tests/Helpers.fs
+++ b/Tests/Helpers.fs
@@ -6,7 +6,7 @@ open Marksman.Misc
 open Marksman.Workspace
 open Marksman.CodeActions
 
-let pathToUri path = $"file://{path}"
+let pathToUri (path: string) = $"file://{path}"
 
 let dummyRoot =
     if RuntimeInformation.IsOSPlatform(OSPlatform.Windows) then
@@ -24,7 +24,7 @@ let checkInlineSnapshot (fmt: 'a -> string) (things: seq<'a>) (snapshot: seq<str
     lines.ShouldMatchInlineSnapshot(snapshot)
 
 let applyDocumentAction (doc: Doc) (action: DocumentAction) : string =
-    let (before, after) = (Doc.text doc).Cutout(action.edit)
+    let before, after = (Doc.text doc).Cutout(action.edit)
 
     before + action.newText + after
 
@@ -46,7 +46,8 @@ type FakeDoc =
             let path = dummyRootPath pathComp
             let pathUri = pathToUri path
             let rootUri = dummyRoot |> pathToUri
-            Doc.mk (PathUri.fromString pathUri) (PathUri.fromString rootUri) None text
+
+            Doc.mk (PathUri.ofString pathUri) (RootPath.ofString rootUri) None text
 
         static member Mk(contentLines: array<string>, ?path: string) : Doc =
             let content = String.concat System.Environment.NewLine contentLines
@@ -58,5 +59,5 @@ type FakeFolder =
         static member Mk(docs: seq<Doc>) : Folder =
             let docsMap = docs |> Seq.map (fun d -> Doc.path d, d) |> Map.ofSeq
 
-            Folder.multiFile "dummy" (PathUri.fromString dummyRootUri) docsMap
+            Folder.multiFile "dummy" (RootPath.ofString dummyRootUri) docsMap
     end

--- a/Tests/Helpers.fs
+++ b/Tests/Helpers.fs
@@ -18,6 +18,8 @@ let dummyRootUri = pathToUri dummyRoot
 
 let dummyRootPath pathComps = dummyRoot + (pathComps |> String.concat "/")
 
+let pathComps (path: string) = path.TrimStart('/').Split("/") |> List.ofArray
+
 let checkInlineSnapshot (fmt: 'a -> string) (things: seq<'a>) (snapshot: seq<string>) =
     let lines = Seq.map (fun x -> (fmt x).Lines()) things |> Seq.concat
 
@@ -39,13 +41,12 @@ let stripMarginTrim (str: string) = stripMargin (str.Trim())
 
 type FakeDoc =
     class
-        static member Mk(content: string, ?path: string) : Doc =
+        static member Mk(content: string, ?path: string, ?root: string) : Doc =
             let text = Text.mkText content
             let path = defaultArg path "fake.md"
-            let pathComp = path.TrimStart('/').Split("/") |> List.ofArray
-            let path = dummyRootPath pathComp
-            let pathUri = pathToUri path
-            let rootUri = dummyRoot |> pathToUri
+            let pathUri = pathToUri (dummyRootPath (pathComps path))
+            let root = Option.map pathComps root |> Option.defaultValue []
+            let rootUri = dummyRootPath root |> pathToUri
 
             Doc.mk (PathUri.ofString pathUri) (RootPath.ofString rootUri) None text
 

--- a/Tests/Helpers.fs
+++ b/Tests/Helpers.fs
@@ -24,7 +24,7 @@ let checkInlineSnapshot (fmt: 'a -> string) (things: seq<'a>) (snapshot: seq<str
     lines.ShouldMatchInlineSnapshot(snapshot)
 
 let applyDocumentAction (doc: Doc) (action: DocumentAction) : string =
-    let (before, after) = doc.text.Cutout(action.edit)
+    let (before, after) = (Doc.text doc).Cutout(action.edit)
 
     before + action.newText + after
 
@@ -56,9 +56,7 @@ type FakeDoc =
 type FakeFolder =
     class
         static member Mk(docs: seq<Doc>) : Folder =
-            let docsMap = docs |> Seq.map (fun d -> d.path, d) |> Map.ofSeq
+            let docsMap = docs |> Seq.map (fun d -> Doc.path d, d) |> Map.ofSeq
 
-            { name = "dummy"
-              root = PathUri.fromString dummyRootUri
-              docs = docsMap }
+            Folder.multiFile "dummy" (PathUri.fromString dummyRootUri) docsMap
     end

--- a/Tests/MiscTests.fs
+++ b/Tests/MiscTests.fs
@@ -91,25 +91,25 @@ module PathUriTests =
     [<Fact>]
     let testWinPathFromUri () =
         let uri = "file:///e%3A/notes"
-        let puri = PathUri.fromString uri
+        let puri = PathUri.ofString uri
 
         Assert.Equal("e:\\notes", puri.LocalPath)
 
     [<Fact>]
     let testWinPathFromPath () =
-        let puri = PathUri.fromString "E:\\notes (precious)"
+        let puri = PathUri.ofString "E:\\notes (precious)"
 
         Assert.Equal("e:\\notes (precious)", puri.LocalPath)
 
     [<Fact>]
     let testWinDocUriFromUri () =
         let uri = "file:///e%3A/notes"
-        let puri = PathUri.fromString uri
+        let puri = PathUri.ofString uri
         Assert.Equal(uri, puri.DocumentUri)
 
     [<Fact>]
     let testWinDocUriFromPath () =
         let path = "E:\\notes"
         let uri = "file:///e%3A/notes"
-        let puri = PathUri.fromString path
+        let puri = PathUri.ofString path
         Assert.Equal(uri, puri.DocumentUri)

--- a/Tests/RefsTests.fs
+++ b/Tests/RefsTests.fs
@@ -118,15 +118,14 @@ let folder = FakeFolder.Mk [ doc1; doc2 ]
 
 let stripRefs (refs: seq<Doc * Element>) =
     refs
-    |> Seq.map (fun (doc, el) ->
-        Path.GetFileName(doc.path.DocumentUri), (Element.range el).DebuggerDisplay)
+    |> Seq.map (fun (doc, el) -> Path.GetFileName(Doc.uri doc), (Element.range el).DebuggerDisplay)
     |> Array.ofSeq
 
 module RefsTests =
     [<Fact>]
     let refToLinkDef_atDef () =
         let def =
-            Cst.elementAtPos (Position.Mk(16, 3)) doc2.cst
+            Cst.elementAtPos (Position.Mk(16, 3)) (Doc.cst doc2)
             |> Option.defaultWith (fun _ -> failwith "No def")
 
         let refs = Dest.findElementRefs false folder doc2 def |> stripRefs
@@ -139,7 +138,7 @@ module RefsTests =
     [<Fact>]
     let refToLinkDef_atDef_withDecl () =
         let def =
-            Cst.elementAtPos (Position.Mk(16, 3)) doc2.cst
+            Cst.elementAtPos (Position.Mk(16, 3)) (Doc.cst doc2)
             |> Option.defaultWith (fun _ -> failwith "No def")
 
         let refs = Dest.findElementRefs true folder doc2 def |> stripRefs
@@ -154,7 +153,7 @@ module RefsTests =
     [<Fact>]
     let refToLinkDef_atLink () =
         let def =
-            Cst.elementAtPos (Position.Mk(8, 4)) doc2.cst
+            Cst.elementAtPos (Position.Mk(8, 4)) (Doc.cst doc2)
             |> Option.defaultWith (fun _ -> failwith "No def")
 
         let refs = Dest.findElementRefs false folder doc2 def |> stripRefs
@@ -167,7 +166,7 @@ module RefsTests =
     [<Fact>]
     let refToLinkDef_atLink_withDecl () =
         let def =
-            Cst.elementAtPos (Position.Mk(8, 4)) doc2.cst
+            Cst.elementAtPos (Position.Mk(8, 4)) (Doc.cst doc2)
             |> Option.defaultWith (fun _ -> failwith "No def")
 
         let refs = Dest.findElementRefs true folder doc2 def |> stripRefs
@@ -182,7 +181,7 @@ module RefsTests =
     [<Fact>]
     let refToDoc_atTitle () =
         let title =
-            Cst.elementAtPos (Position.Mk(0, 2)) doc1.cst
+            Cst.elementAtPos (Position.Mk(0, 2)) (Doc.cst doc1)
             |> Option.defaultWith (fun _ -> failwith "No title")
 
         let refs = Dest.findElementRefs false folder doc1 title |> stripRefs
@@ -197,7 +196,7 @@ module RefsTests =
     [<Fact>]
     let refToDoc_atTitle_withDecl () =
         let title =
-            Cst.elementAtPos (Position.Mk(0, 2)) doc1.cst
+            Cst.elementAtPos (Position.Mk(0, 2)) (Doc.cst doc1)
             |> Option.defaultWith (fun _ -> failwith "No title")
 
         let refs = Dest.findElementRefs true folder doc1 title |> stripRefs
@@ -213,7 +212,7 @@ module RefsTests =
     [<Fact>]
     let refToDoc_atLink () =
         let wl =
-            Cst.elementAtPos (Position.Mk(4, 4)) doc1.cst
+            Cst.elementAtPos (Position.Mk(4, 4)) (Doc.cst doc1)
             |> Option.defaultWith (fun _ -> failwith "No title")
 
         let refs = Dest.findElementRefs false folder doc1 wl |> stripRefs
@@ -226,7 +225,7 @@ module RefsTests =
     [<Fact>]
     let refToDoc_atLink_withDecl () =
         let wl =
-            Cst.elementAtPos (Position.Mk(4, 4)) doc1.cst
+            Cst.elementAtPos (Position.Mk(4, 4)) (Doc.cst doc1)
             |> Option.defaultWith (fun _ -> failwith "No title")
 
         let refs = Dest.findElementRefs true folder doc1 wl |> stripRefs
@@ -237,5 +236,3 @@ module RefsTests =
             [ "(doc2.md, (10,0)-(10,9))"
               "(doc1.md, (4,0)-(4,16))"
               "(doc2.md, (6,0)-(6,11))" ]
-
-// TODO: add tests for title refs

--- a/Tests/RefsTests.fs
+++ b/Tests/RefsTests.fs
@@ -13,8 +13,11 @@ open Marksman.Refs
 module DocRefTests =
     [<Fact>]
     let relPath_1 () =
-        let folder = dummyRootPath [ "rootFolder" ]
-        let docPath = dummyRootPath [ "rootFolder"; "subfolder"; "sub.md" ]
+        let folder = dummyRootPath [ "rootFolder" ] |> RootPath.ofString
+
+        let docPath =
+            dummyRootPath [ "rootFolder"; "subfolder"; "sub.md" ]
+            |> PathUri.ofString
 
         let actual =
             DocRef.tryResolveToRootPath folder docPath "../doc.md" |> Option.get
@@ -23,8 +26,10 @@ module DocRefTests =
 
     [<Fact>]
     let relPath_2 () =
-        let folder = dummyRootPath [ "rootFolder" ]
-        let docPath = dummyRootPath [ "rootFolder"; "doc1.md" ]
+        let folder = dummyRootPath [ "rootFolder" ] |> RootPath.ofString
+
+        let docPath =
+            dummyRootPath [ "rootFolder"; "doc1.md" ] |> PathUri.ofString
 
         let actual =
             DocRef.tryResolveToRootPath folder docPath "./doc2.md" |> Option.get
@@ -33,16 +38,21 @@ module DocRefTests =
 
     [<Fact>]
     let relPath_non_exist () =
-        let folder = dummyRootPath [ "rootFolder" ]
-        let docPath = dummyRootPath [ "rootFolder"; "doc1.md" ]
+        let folder = dummyRootPath [ "rootFolder" ] |> RootPath.ofString
+
+        let docPath =
+            dummyRootPath [ "rootFolder"; "doc1.md" ] |> PathUri.ofString
 
         let actual = DocRef.tryResolveToRootPath folder docPath "../doc2.md"
         Assert.Equal(None, actual)
 
     [<Fact>]
     let rootPath () =
-        let folder = dummyRootPath [ "rootFolder" ]
-        let docPath = dummyRootPath [ "rootFolder"; "subfolder"; "sub.md" ]
+        let folder = dummyRootPath [ "rootFolder" ] |> RootPath.ofString
+
+        let docPath =
+            dummyRootPath [ "rootFolder"; "subfolder"; "sub.md" ]
+            |> PathUri.ofString
 
         let actual =
             DocRef.tryResolveToRootPath folder docPath "/doc.md" |> Option.get
@@ -51,8 +61,11 @@ module DocRefTests =
 
     [<Fact>]
     let url_no_schema_FP () =
-        let folder = dummyRootPath [ "rootFolder" ]
-        let docPath = dummyRootPath [ "rootFolder"; "subfolder"; "sub.md" ]
+        let folder = dummyRootPath [ "rootFolder" ] |> RootPath.ofString
+
+        let docPath =
+            dummyRootPath [ "rootFolder"; "subfolder"; "sub.md" ]
+            |> PathUri.ofString
 
         let actual =
             DocRef.tryResolveToRootPath folder docPath "www.google.com"
@@ -62,8 +75,11 @@ module DocRefTests =
 
     [<Fact>]
     let url_schema () =
-        let folder = dummyRootPath [ "rootFolder" ]
-        let docPath = dummyRootPath [ "rootFolder"; "subfolder"; "sub.md" ]
+        let folder = dummyRootPath [ "rootFolder" ] |> RootPath.ofString
+
+        let docPath =
+            dummyRootPath [ "rootFolder"; "subfolder"; "sub.md" ]
+            |> PathUri.ofString
 
         let actual =
             DocRef.tryResolveToRootPath folder docPath "http://www.google.com"

--- a/Tests/SematoTests.fs
+++ b/Tests/SematoTests.fs
@@ -6,12 +6,13 @@ open Marksman.Workspace
 open Marksman.Semato
 open Xunit
 
-let folderPath = PathUri.fromString (dummyRootPath [ "folder" ])
+let folderPath = (dummyRootPath [ "folder" ]) |> RootPath.ofString
+
 let nthToken (data: array<uint32>) n = data[n * 5 .. n * 5 + 4]
 
 [<Fact>]
 let testEncoding () =
-    let docPath = dummyRootPath [ "folder"; "doc1.md" ] |> PathUri.fromString
+    let docPath = dummyRootPath [ "folder"; "doc1.md" ] |> PathUri.ofString
 
     let content =
         """# Title

--- a/Tests/SematoTests.fs
+++ b/Tests/SematoTests.fs
@@ -21,7 +21,7 @@ Start with [[a-wiki-link]]. Then a [ref-link].
 End with [[wiki-link-no-eol]]"""
 
     let doc = Doc.mk docPath folderPath None (Text.mkText content)
-    let data = Token.ofIndexEncoded doc.index
+    let data = Token.ofIndexEncoded (Doc.index doc)
     Assert.Equal(4 * 5, data.Length)
 
     Assert.Equal<uint32>([| 1u; 11u; 15u; 0u; 0u |], nthToken data 0)

--- a/Tests/TocTests.fs
+++ b/Tests/TocTests.fs
@@ -1,5 +1,6 @@
 module Marksman.TocTests
 
+open Marksman.Workspace
 open Xunit
 
 open Marksman.Helpers
@@ -12,7 +13,7 @@ module DetectToc =
     let detectToc_1 () =
         let doc = FakeDoc.Mk "# T1\n# T2"
 
-        let titles = TableOfContents.detect doc.text
+        let titles = TableOfContents.detect (Doc.text doc)
 
         Assert.Equal(titles, None)
 
@@ -21,7 +22,7 @@ module DetectToc =
         let doc =
             FakeDoc.Mk [| "- [T1][#t1]"; " - [T2][#t2]"; ""; ""; "# T1"; "## T2" |]
 
-        let titles = TableOfContents.detect doc.text
+        let titles = TableOfContents.detect (Doc.text doc)
 
         Assert.Equal(titles, None)
 
@@ -36,11 +37,11 @@ module DetectToc =
                    "# T1"
                    "## T2" |]
 
-        let toc = (TableOfContents.detect doc.text).Value
-        let tocText = doc.text.Substring toc
+        let toc = (TableOfContents.detect (Doc.text doc)).Value
+        let tocText = (Doc.text doc).Substring toc
 
         let expectedTocText =
-            let line num = doc.text.LineContent(num)
+            let line num = (Doc.text doc).LineContent(num)
 
             String.concat System.Environment.NewLine ([| 0..3 |] |> Array.map line)
 
@@ -54,7 +55,7 @@ module CreateToc =
     let createToc () =
         let doc = FakeDoc.Mk [| "# T1"; "## T2" |]
 
-        let titles = TableOfContents.mk doc.index |> Option.get
+        let titles = TableOfContents.mk (Doc.index doc) |> Option.get
 
         let expected = { entries = [| Entry.Mk(1, "T1"); Entry.Mk(2, "T2") |] }
 
@@ -72,7 +73,7 @@ module CreateToc =
                    "# T1"
                    "## T2" |]
 
-        let titles = TableOfContents.mk doc.index |> Option.get
+        let titles = TableOfContents.mk (Doc.index doc) |> Option.get
 
         let expected = { entries = [| Entry.Mk(1, "T1"); Entry.Mk(2, "T2") |] }
 
@@ -96,7 +97,7 @@ module InsertToc =
         let doc = FakeDoc.Mk [| "# T1"; "## T2" |]
 
         let insertion = TableOfContents.insertionPoint doc
-        let firstTitleRange = Array.head(doc.index.titles).range
+        let firstTitleRange = Array.head((Doc.index doc).titles).range
 
         Assert.Equal(insertion, After firstTitleRange)
 
@@ -114,7 +115,7 @@ module InsertToc =
 
 
         let insertion = TableOfContents.insertionPoint doc
-        let yamlRange = Option.get(doc.index.yamlFrontMatter).range
+        let yamlRange = Option.get((Doc.index doc).yamlFrontMatter).range
 
         Assert.Equal(insertion, After yamlRange)
 
@@ -132,7 +133,7 @@ module InsertToc =
 
 
         let insertion = TableOfContents.insertionPoint doc
-        let firstTitleRange = Array.head(doc.index.titles).range
+        let firstTitleRange = Array.head((Doc.index doc).titles).range
 
         Assert.Equal(insertion, After firstTitleRange)
 
@@ -143,7 +144,9 @@ module RenderToc =
         let doc = FakeDoc.Mk [| "# T1"; "## T2"; "### T3"; "## T4"; "### T5" |]
 
         let titles =
-            TableOfContents.mk doc.index |> Option.get |> TableOfContents.render
+            TableOfContents.mk (Doc.index doc)
+            |> Option.get
+            |> TableOfContents.render
 
         let expectedLines =
             [| StartMarker
@@ -327,7 +330,7 @@ module DocumentEdit =
         let action = CodeActions.tableOfContents doc
 
         Assert.Equal(None, action)
-        
+
     [<Fact>]
     let upToDate_whitespace_noUpdate () =
         let text =

--- a/Tests/WorkspaceTest.fs
+++ b/Tests/WorkspaceTest.fs
@@ -63,11 +63,7 @@ module DocTest =
         let dummyPath = (dummyRootPath [ "dummy.md" ])
 
         let empty =
-            Doc.mk
-                (PathUri.fromString dummyPath)
-                (PathUri.fromString dummyRoot)
-                None
-                (Text.mkText "")
+            Doc.mk (PathUri.ofString dummyPath) (RootPath.ofString dummyRoot) None (Text.mkText "")
 
         let insertChange =
             { TextDocument = { Uri = pathToUri dummyPath; Version = Some 1 }

--- a/Tests/WorkspaceTest.fs
+++ b/Tests/WorkspaceTest.fs
@@ -15,46 +15,46 @@ module FolderTests =
         [<Fact>]
         let absGlob_Unix () =
             if not (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) then
-                let glob = Folder.buildGlobs ([| "/node_modules" |])
+                let glob = buildGlobs [| "/node_modules" |]
                 let root = "/Users/john/notes"
                 let ignored = "/Users/john/notes/node_modules"
-                Folder.shouldBeIgnored glob root ignored |> Assert.True
+                shouldBeIgnored glob root ignored |> Assert.True
 
                 let notIgnored = "/Users/john/notes/real.md"
-                Folder.shouldBeIgnored glob root notIgnored |> Assert.False
+                shouldBeIgnored glob root notIgnored |> Assert.False
 
         [<Fact>]
         let relGlob_Unix () =
             if not (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) then
-                let glob = Folder.buildGlobs ([| "a/b" |])
+                let glob = buildGlobs [| "a/b" |]
                 let root = "/Users/john/notes"
                 let ignored = "/Users/john/notes/a/b"
-                Folder.shouldBeIgnored glob root ignored |> Assert.True
+                shouldBeIgnored glob root ignored |> Assert.True
 
                 let notIgnored = "/Users/john/notes/a/real.md"
-                Folder.shouldBeIgnored glob root notIgnored |> Assert.False
+                shouldBeIgnored glob root notIgnored |> Assert.False
 
         [<Fact>]
         let absGlob_Win () =
             if RuntimeInformation.IsOSPlatform(OSPlatform.Windows) then
-                let glob = Folder.buildGlobs ([| "/node_modules" |])
+                let glob = buildGlobs [| "/node_modules" |]
                 let root = "C:\\notes"
                 let ignored = "C:\\notes\\node_modules"
-                Folder.shouldBeIgnored glob root ignored |> Assert.True
+                shouldBeIgnored glob root ignored |> Assert.True
 
                 let notIgnored = "C:\\notes\\real.md"
-                Folder.shouldBeIgnored glob root notIgnored |> Assert.False
+                shouldBeIgnored glob root notIgnored |> Assert.False
 
         [<Fact>]
         let relGlob_Win () =
             if RuntimeInformation.IsOSPlatform(OSPlatform.Windows) then
-                let glob = Folder.buildGlobs ([| "a/b" |])
+                let glob = buildGlobs [| "a/b" |]
                 let root = "C:\\notes"
                 let ignored = "C:\\notes\\a\\b"
-                Folder.shouldBeIgnored glob root ignored |> Assert.True
+                shouldBeIgnored glob root ignored |> Assert.True
 
                 let notIgnored = "C:\\notes\\a\\real.md"
-                Folder.shouldBeIgnored glob root notIgnored |> Assert.False
+                shouldBeIgnored glob root notIgnored |> Assert.False
 
 
 module DocTest =
@@ -77,4 +77,4 @@ module DocTest =
                      Text = "[" } |] }
 
         let updated = Doc.applyLspChange insertChange empty
-        Assert.Equal("[", updated.text.content)
+        Assert.Equal("[", (Doc.text updated).content)


### PR DESCRIPTION
Resolves #69 

TODO:
* [x] Create "single-file" folders
* [x] Automatically create single-file folders when a document outside of existing workspace folders is opened
* [x] Remove single-file folders from the workspace when their file gets closed/deleted
* [x] Evict single-file folders from the workspace when a real folder with a /wider/ path is added
* [x] Suppress cross-file diag for single-file folders
* [x] Update README