### PR TITLE
Update README re: Helix editor configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,20 +65,6 @@ for wiki-links to detect broken references and duplicate/ambiguous headings.
       (add-to-list 'eglot-server-programs '(markdown-mode . ("marksman")))      
       (add-hook 'markdown-mode-hook #'eglot-ensure)
       ````
-* [Helix][helix-editor] requires configuration (unless
-  [helix#3499][helix-marksman-pr] gets merged); add the following to your
-  `~/.config/helix/languages.toml`:
-
-  ```toml
-  [[language]]
-  name = "markdown"
-  scope = "source.md"
-  injection-regex = "md|markdown"
-  file-types = ["md"]
-  roots = [".marksman.toml"]
-  language-server = { command = "marksman", args=["server"] }
-  indent = { tab-width = 2, unit = "  " }
-  ```
 * Sublime Text via [LSP-marksman][sublime-marksman] (automatic server
   installation).
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ for wiki-links to detect broken references and duplicate/ambiguous headings.
       (add-to-list 'eglot-server-programs '(markdown-mode . ("marksman")))      
       (add-hook 'markdown-mode-hook #'eglot-ensure)
       ````
-* [Helix](https://helix-editor.com/) works out of the box if the binary is somewhere in your `PATH`
+* [Helix](https://helix-editor.com/) supports Marksman out of the box. However, you need add `marksman` binary to your `PATH` manually.
 * Sublime Text via [LSP-marksman][sublime-marksman] (automatic server
   installation).
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@ for wiki-links to detect broken references and duplicate/ambiguous headings.
       (add-to-list 'eglot-server-programs '(markdown-mode . ("marksman")))      
       (add-hook 'markdown-mode-hook #'eglot-ensure)
       ````
-
 * [Helix](https://helix-editor.com/) works out of the box if the binary is somewhere in your `PATH`
 * Sublime Text via [LSP-marksman][sublime-marksman] (automatic server
   installation).

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ for wiki-links to detect broken references and duplicate/ambiguous headings.
       (add-to-list 'eglot-server-programs '(markdown-mode . ("marksman")))      
       (add-hook 'markdown-mode-hook #'eglot-ensure)
       ````
+
+* [Helix](https://helix-editor.com/) works out of the box if the binary is somewhere in your `PATH`
 * Sublime Text via [LSP-marksman][sublime-marksman] (automatic server
   installation).
 


### PR DESCRIPTION
[helix#4399](https://github.com/helix-editor/helix/pull/3499) was merged. After installing the marksman binary, markdown worked in Helix as expected.