### PR TITLE
feat: Add user and project level configuration

### DIFF
--- a/Marksman/Config.fs
+++ b/Marksman/Config.fs
@@ -50,6 +50,7 @@ let private getFromTableOpt<'R> table revSeenPath remPath : Result<option<'R>, L
 
 type TocConfig =
     { enable: option<bool> }
+
     static member Default = { enable = Some true }
     member this.EnableOrDefault() = this.enable |> Option.defaultValue true
 
@@ -58,6 +59,7 @@ module TocConfig =
 
 type CodeActionConfig =
     { toc: option<TocConfig> }
+
     static member Default = { toc = Some TocConfig.Default }
     member this.TocOrDefault() = this.toc |> Option.defaultValue TocConfig.Default
 
@@ -66,6 +68,7 @@ module CodeActionConfig =
 
 type Config =
     { codeAction: option<CodeActionConfig> }
+
     member this.CodeActionOrDefault() =
         this.codeAction |> Option.defaultValue CodeActionConfig.Default
 

--- a/Marksman/Config.fs
+++ b/Marksman/Config.fs
@@ -2,29 +2,88 @@ module Marksman.Config
 
 open System.IO
 open Tomlyn
+open Tomlyn.Model
 
-type TocConfig = { enable: bool }
-type CodeActionConfig = { toc: TocConfig }
-type Config = { codeAction: CodeActionConfig }
+open FSharpPlus.GenericBuilders
 
-module Serde =
-    type TocConfig() =
-        member val Enable: bool = true with get, set
-        member this.Build() = { enable = this.Enable }
+type LookupError =
+    | NotFound of path: list<string>
+    | WrongType of path: list<string> * value: obj * expectedType: System.Type
 
-    type CodeActionConfig() =
-        member val Toc = TocConfig() with get, set
-        member this.Build() = { toc = this.Toc.Build() }
+type LookupResult<'R> = Result<'R, LookupError>
 
-    type Config() =
-        member val CodeAction = CodeActionConfig() with get, set
-        member this.Build() = { codeAction = this.CodeAction.Build() }
+let private getFromTable<'R>
+    (table: TomlTable)
+    (revContext: list<string>)
+    (path: list<string>)
+    : LookupResult<'R> =
+    let rec go (table: TomlTable) revContext path =
+        match path with
+        | [] -> failwith "getFromTable unreachable"
+        | [ last ] ->
+            match table.TryGetValue(last) with
+            | true, value ->
+                match value with
+                | :? 'T as value -> Ok value
+                | _ -> Error(WrongType(List.rev (last :: revContext), value, typeof<'T>))
+            | false, _ -> Error(NotFound(List.rev (last :: revContext)))
+        | next :: tail ->
+            match table.TryGetValue(next) with
+            | true, value ->
+                match value with
+                | :? TomlTable as nextTable -> go nextTable (next :: revContext) tail
+                | _ -> Error(WrongType(List.rev (next :: revContext), value, typeof<TomlTable>))
+            | false, _ -> Error(NotFound(List.rev (next :: revContext)))
 
+    match path with
+    | [] -> failwith "Cannot query a table with an empty path"
+    | path -> go table revContext path
+
+let lookupAsOpt =
+    function
+    | Ok found -> Ok(Some found)
+    | Error (NotFound _) -> Ok None
+    | Error err -> Error err
+
+let getFromTableOpt<'R> table revSeenPath remPath : Result<option<'R>, LookupError> =
+    getFromTable table revSeenPath remPath |> lookupAsOpt
+
+type TocConfig = { enable: option<bool> }
+type CodeActionConfig = { toc: option<TocConfig> }
+type Config = { codeAction: option<CodeActionConfig> }
+
+let tocOfTable (context: list<string>) (table: TomlTable) : LookupResult<TocConfig> =
+    monad' {
+        let! enable = getFromTableOpt<bool> table context [ "enable" ]
+        { enable = enable }
+    }
+
+let caOfTable (context: list<string>) (table: TomlTable) : LookupResult<CodeActionConfig> =
+    monad' {
+        let! toc =
+            getFromTable<TomlTable> table context [ "toc" ]
+            |> Result.bind (tocOfTable ("toc" :: context))
+            |> lookupAsOpt
+
+        { toc = toc }
+    }
+
+let configOfTable (context: list<string>) (table: TomlTable) : LookupResult<Config> =
+    monad {
+        let! ca =
+            getFromTable<TomlTable> table [] [ "code_action" ]
+            |> Result.bind (caOfTable ("code_action" :: context))
+            |> lookupAsOpt
+
+        { codeAction = ca }
+    }
 
 let tryParse (content: string) =
-    let isOk, toml, _diag = Toml.TryToModel<Serde.Config>(content)
+    let table = Toml.ToModel(content)
 
-    if not isOk then None else Some(toml.Build())
+    match configOfTable [] table with
+    | Ok parsed -> Some parsed
+    | _ -> None
 
 let read (filepath: string) =
     try

--- a/Marksman/Workspace.fsi
+++ b/Marksman/Workspace.fsi
@@ -50,12 +50,16 @@ module Folder =
     val id: Folder -> FolderId
     val rootPath: Folder -> RootPath
 
+    val config: Folder -> option<Config>
+    val configOrDefault: Folder -> Config
+    val withConfig: option<Config> -> Folder -> Folder
+
     val docs: Folder -> seq<Doc>
     val docCount: Folder -> int
 
     val tryLoad: name: string -> root: RootPath -> option<Folder>
 
-    val singleFile: Doc -> Folder
+    val singleFile: doc: Doc -> config: option<Config> -> Folder
     val multiFile: name: string -> root: RootPath -> docs: Map<PathUri, Doc> -> config: option<Config> -> Folder
     val isSingleFile: Folder -> bool
 
@@ -72,10 +76,11 @@ type Workspace
 module Workspace =
     val folders: Workspace -> seq<Folder>
     val docCount: Workspace -> int
+    val userConfig: Workspace -> option<Config>
 
+    val ofFolders: userConfig: option<Config> -> seq<Folder> -> Workspace
     val withFolder: Folder -> Workspace -> Workspace
     val withFolders: seq<Folder> -> Workspace -> Workspace
-    val ofFolders: seq<Folder> -> Workspace
 
     val withoutFolder: FolderId -> Workspace -> Workspace
     val withoutFolders: seq<FolderId> -> Workspace -> Workspace

--- a/Marksman/Workspace.fsi
+++ b/Marksman/Workspace.fsi
@@ -3,6 +3,7 @@ module Marksman.Workspace
 open Ionide.LanguageServerProtocol.Types
 
 open Marksman.Misc
+open Marksman.Config
 open Marksman.Cst
 open Marksman.Index
 open Marksman.Text
@@ -55,7 +56,7 @@ module Folder =
     val tryLoad: name: string -> root: RootPath -> option<Folder>
 
     val singleFile: Doc -> Folder
-    val multiFile: name: string -> root: RootPath -> docs: Map<PathUri, Doc> -> Folder
+    val multiFile: name: string -> root: RootPath -> docs: Map<PathUri, Doc> -> config: option<Config> -> Folder
     val isSingleFile: Folder -> bool
 
     val withDoc: Doc -> Folder -> Folder

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ generally most features should work equaly in all editors.
 
 - ✅ Document symbols from headings.
 - ✅ Workspace symbols from headings.
-  * Query matching is subsequence-based, that is `lsp` will match both `LSP` and `Low Seimic Profile`.
+  * Query matching is subsequence-based, that is `lsp` will match both `LSP` and `Low Seismic Profile`.
 - ✅ Completion for links (inline, reference, wiki).
 - ✅ Hover prevew for links.
 - ✅ "Go to definition" for links.
@@ -141,6 +141,9 @@ generally most features should work equaly in all editors.
   relative markdown links for further embedding into a static site generator
   such as Jekyll or Hakyll.
 - 🗓  Support for Jupyter notebooks.
+
+### Configuration
+See [Configuration](docs/configuration.md) docs for more details.
 
 ### Code actions
 

--- a/Tests/ConfigTests.fs
+++ b/Tests/ConfigTests.fs
@@ -12,7 +12,7 @@ let testParse_0 () =
 
     let actual = Config.tryParse content
 
-    let expected = { codeAction = None }
+    let expected = { caTocEnable = None }
 
     Assert.Equal(Some expected, actual)
 
@@ -24,7 +24,7 @@ let testParse_1 () =
 """
 
     let actual = Config.tryParse content
-    let expected = { codeAction = Some { toc = None } }
+    let expected = { caTocEnable = None }
     Assert.Equal(Some expected, actual)
 
 [<Fact>]
@@ -37,7 +37,14 @@ toc.enable = false
 
     let actual = Config.tryParse content
 
-    let expected =
-        { codeAction = Some { toc = Some { enable = Some false } } }
+    let expected = { caTocEnable = Some false }
 
     Assert.Equal(Some expected, actual)
+
+[<Fact>]
+let testParse_broken_0 () =
+    let content = """
+blah
+"""
+    let actual = Config.tryParse content
+    Assert.Equal(None, actual)

--- a/Tests/ConfigTests.fs
+++ b/Tests/ConfigTests.fs
@@ -1,5 +1,7 @@
 module Marksman.ConfigTests
 
+open System.IO
+open System.Reflection
 open Xunit
 
 open Marksman.Config
@@ -43,8 +45,17 @@ toc.enable = false
 
 [<Fact>]
 let testParse_broken_0 () =
-    let content = """
+    let content =
+        """
 blah
 """
+
     let actual = Config.tryParse content
     Assert.Equal(None, actual)
+
+[<Fact>]
+let testDefault () =
+    let content = Assembly.GetExecutingAssembly().GetManifestResourceStream("default.marksman.toml")
+    let content = using (new StreamReader(content)) (fun f -> f.ReadToEnd())
+    let parsed = Config.tryParse content
+    Assert.Equal(Some Config.Default, parsed)

--- a/Tests/ConfigTests.fs
+++ b/Tests/ConfigTests.fs
@@ -2,6 +2,8 @@ module Marksman.ConfigTests
 
 open Xunit
 
+open Marksman.Config
+
 [<Fact>]
 let testParse_0 () =
     let content =
@@ -10,7 +12,7 @@ let testParse_0 () =
 
     let actual = Config.tryParse content
 
-    let expected = { Config.codeAction = None }
+    let expected = { codeAction = None }
 
     Assert.Equal(Some expected, actual)
 
@@ -22,7 +24,7 @@ let testParse_1 () =
 """
 
     let actual = Config.tryParse content
-    let expected = { Config.codeAction = Some { toc = None } }
+    let expected = { codeAction = Some { toc = None } }
     Assert.Equal(Some expected, actual)
 
 [<Fact>]
@@ -36,6 +38,6 @@ toc.enable = false
     let actual = Config.tryParse content
 
     let expected =
-        { Config.codeAction = Some { toc = Some { enable = Some false } } }
+        { codeAction = Some { toc = Some { enable = Some false } } }
 
     Assert.Equal(Some expected, actual)

--- a/Tests/ConfigTests.fs
+++ b/Tests/ConfigTests.fs
@@ -9,7 +9,9 @@ let testParse_0 () =
 """
 
     let actual = Config.tryParse content
-    let expected = { Config.codeAction = { toc = { enable = true } } }
+
+    let expected = { Config.codeAction = None }
+
     Assert.Equal(Some expected, actual)
 
 [<Fact>]
@@ -20,7 +22,7 @@ let testParse_1 () =
 """
 
     let actual = Config.tryParse content
-    let expected = { Config.codeAction = { toc = { enable = true } } }
+    let expected = { Config.codeAction = Some { toc = None } }
     Assert.Equal(Some expected, actual)
 
 [<Fact>]
@@ -32,5 +34,8 @@ toc.enable = false
 """
 
     let actual = Config.tryParse content
-    let expected = { Config.codeAction = { toc = { enable = false } } }
+
+    let expected =
+        { Config.codeAction = Some { toc = Some { enable = Some false } } }
+
     Assert.Equal(Some expected, actual)

--- a/Tests/DiagTest.fs
+++ b/Tests/DiagTest.fs
@@ -95,7 +95,7 @@ let noCrossFileDiagOnSingleFileFolders () =
                "[bad-ref][bad-ref]" |]
         )
 
-    let folder = Folder.singleFile doc
+    let folder = Folder.singleFile doc None
     let diag = checkFolder folder |> diagToHuman
 
     Assert.Equal<string * string>(

--- a/Tests/Helpers.fs
+++ b/Tests/Helpers.fs
@@ -60,5 +60,5 @@ type FakeFolder =
         static member Mk(docs: seq<Doc>) : Folder =
             let docsMap = docs |> Seq.map (fun d -> Doc.path d, d) |> Map.ofSeq
 
-            Folder.multiFile "dummy" (RootPath.ofString dummyRootUri) docsMap
+            Folder.multiFile "dummy" (RootPath.ofString dummyRootUri) docsMap None
     end

--- a/Tests/Tests.fsproj
+++ b/Tests/Tests.fsproj
@@ -23,7 +23,10 @@
         <Compile Include="ConfigTests.fs" />
         <Compile Include="GitIgnoreTest.fs" />
         <Compile Include="Program.fs" />
-        <Content Include="default.marksman.toml" />
+    </ItemGroup>
+    
+    <ItemGroup>
+        <EmbeddedResource Include="default.marksman.toml" LogicalName="default.marksman.toml" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Tests/WorkspaceTest.fs
+++ b/Tests/WorkspaceTest.fs
@@ -46,7 +46,7 @@ module WorkspaceTest =
         let ws = Workspace.ofFolders [ f1; f2 ]
 
         let f0Path = dummyRootPath [ "a" ] |> PathUri.ofString
-        let f0 = Folder.multiFile "f0" (RootPath.ofPath f0Path) Map.empty
+        let f0 = Folder.multiFile "f0" (RootPath.ofPath f0Path) Map.empty None
 
         let updWs = Workspace.withFolder f0 ws
 

--- a/Tests/default.marksman.toml
+++ b/Tests/default.marksman.toml
@@ -1,0 +1,6 @@
+# This file lists all configuration options with their default values.
+# You do not need to duplicate all the values in your own user or project config.
+# Only override what is needed.
+
+[code_action]
+toc.enable = true # Enable/disable "Table of Contents" code action

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,15 @@
+﻿# Configuration
+
+Marksman supports user-level and project-level configuration:
+1. User-level configuration is read from:
+   * `$HOME/.config/marksman/config.toml` on Linux and MacOS,
+   * `$HOME\\AppData\\Roaming\\marksman\\config.toml` on Windows.
+2. Project-level configuration is read from `.marksman.toml` located in the project's root folder.
+
+For each configuration option the precedence is: project config > user config > global default.
+
+[This config file](../Tests/default.marksman.toml) shows all configuration options with their
+default values. You need to specify ONLY the options you wish to override in your user- or
+project-config.
+
+


### PR DESCRIPTION
The purpose of this PR is to add configuration
1. User level config in `~/.config/marksman/config.toml` (or `$HOME\\AppData\\Roaming\\marksman\\config.toml` on Windows)
2. Project-level config in `[project-folder]/.marksman.toml`

Project-level config overrides values in user-level configs.