### PR TITLE
ca: Allow to enable/disable ToC code action

### DIFF
--- a/Marksman/Config.fs
+++ b/Marksman/Config.fs
@@ -58,6 +58,11 @@ type Config =
 
     static member Default = { caTocEnable = Some true }
 
+    member this.CaTocEnable() =
+        this.caTocEnable
+        |> Option.orElse (Config.Default.caTocEnable)
+        |> Option.get
+
 let private configOfTable (table: TomlTable) : LookupResult<Config> =
     monad {
         let! caTocEnable = getFromTableOpt<bool> table [] [ "code_action"; "toc"; "enable" ]

--- a/README.md
+++ b/README.md
@@ -84,13 +84,13 @@ for wiki-links to detect broken references and duplicate/ambiguous headings.
 
 **NOTE**: If you're on MacOS and are getting a popup about:
 
-> “marksman” can’t be opened because Apple cannot check it for malicious software
+> “marksman” can’t be opened because Apple cannot check it for malicious software...
 
 Then you can run the following command to bypass it and let Mac know that it's
-fine.
+fine:
 
 ```sh
-xattr -d com.apple.quarantine ~/bin/marksman
+xattr -d com.apple.quarantine <path-to-marksman-bin>
 ```
 
 ### Option 2: build from source

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ generally most features should work equaly in all editors.
 - **Rename refactor for headings and reference links**:
   ![Rename Refactor](assets/readme/gifs/rename.gif)
 
-## Features and plans
+## Features
 
 ✅ - done; 🗓 - planned.
 
@@ -147,8 +147,11 @@ See [Configuration](docs/configuration.md) docs for more details.
 
 ### Code actions
 
-**Table of Contents**: Marksman has a code action to create and update a table
-of contents of a document.
+Code actions usually can be enabled/disabled via a configuration option. See
+[configuration](#configuration) for more details.
+
+#### Table of Contents
+Marksman has a code action to create and update a table of contents of a document.
 
 ![Table of Contents](assets/readme/gifs/toc.gif)
 


### PR DESCRIPTION
The config option was added earlier. This PR make the code action to take the config into account.