### PR TITLE
core: Allow configuring recognized markdown file extensions

### DIFF
--- a/Marksman.sln.DotSettings
+++ b/Marksman.sln.DotSettings
@@ -1,6 +1,7 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=clippy/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Compl/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=exts/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=noti/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Semato/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=uref/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/Marksman/Config.fs
+++ b/Marksman/Config.fs
@@ -89,33 +89,33 @@ let private getFromTableOpt<'R> table revSeenPath remPath : Result<option<'R>, L
 /// without lenses manageable.
 type Config =
     { caTocEnable: option<bool>
-      coreMarkdownExtensions: option<array<string>> }
+      coreMarkdownFileExtensions: option<array<string>> }
 
     static member Default =
         { caTocEnable = Some true
-          coreMarkdownExtensions = Some [| "md"; "markdown" |] }
+          coreMarkdownFileExtensions = Some [| "md"; "markdown" |] }
 
-    static member Empty = { caTocEnable = None; coreMarkdownExtensions = None }
+    static member Empty = { caTocEnable = None; coreMarkdownFileExtensions = None }
 
     member this.CaTocEnable() =
         this.caTocEnable
         |> Option.orElse Config.Default.caTocEnable
         |> Option.get
 
-    member this.CoreMarkdownExtensions() =
-        this.coreMarkdownExtensions
-        |> Option.orElse Config.Default.coreMarkdownExtensions
+    member this.CoreMarkdownFileExtensions() =
+        this.coreMarkdownFileExtensions
+        |> Option.orElse Config.Default.coreMarkdownFileExtensions
         |> Option.get
 
 let private configOfTable (table: TomlTable) : LookupResult<Config> =
     monad {
         let! caTocEnable = getFromTableOpt<bool> table [] [ "code_action"; "toc"; "enable" ]
 
-        let! coreMarkdownExtensions =
-            getFromTableOpt<array<string>> table [] [ "core"; "markdown"; "extensions" ]
+        let! coreMarkdownFileExtensions =
+            getFromTableOpt<array<string>> table [] [ "core"; "markdown"; "file_extensions" ]
 
         { caTocEnable = caTocEnable
-          coreMarkdownExtensions = coreMarkdownExtensions }
+          coreMarkdownFileExtensions = coreMarkdownFileExtensions }
     }
 
 module Config =
@@ -123,8 +123,9 @@ module Config =
 
     let merge hi low =
         { caTocEnable = hi.caTocEnable |> Option.orElse low.caTocEnable
-          coreMarkdownExtensions =
-            hi.coreMarkdownExtensions |> Option.orElse low.coreMarkdownExtensions }
+          coreMarkdownFileExtensions =
+            hi.coreMarkdownFileExtensions
+            |> Option.orElse low.coreMarkdownFileExtensions }
 
     let tryParse (content: string) =
         let mutable table, diag = null, null

--- a/Marksman/Config.fs
+++ b/Marksman/Config.fs
@@ -127,6 +127,14 @@ module Config =
             hi.coreMarkdownFileExtensions
             |> Option.orElse low.coreMarkdownFileExtensions }
 
+    let mergeOpt hi low =
+        match low with
+        | None -> hi
+        | Some low ->
+            match hi with
+            | None -> Some low
+            | Some hi -> Some(merge hi low)
+
     let tryParse (content: string) =
         let mutable table, diag = null, null
         let ok = Toml.TryToModel(content, &table, &diag)

--- a/Marksman/Config.fs
+++ b/Marksman/Config.fs
@@ -76,7 +76,8 @@ module Config =
     let merge hi low = { caTocEnable = hi.caTocEnable |> Option.orElse low.caTocEnable }
 
     let tryParse (content: string) =
-        let ok, table, _ = Toml.TryToModel(content)
+        let mutable table, diag = null, null
+        let ok = Toml.TryToModel(content, &table, &diag)
 
         if ok then
             logger.trace (Log.setMessage "Parsing as TOML was successful")

--- a/Marksman/Config.fs
+++ b/Marksman/Config.fs
@@ -13,6 +13,40 @@ type LookupError =
 
 type LookupResult<'R> = Result<'R, LookupError>
 
+module LookupResult =
+    let collect (results: list<option<'R>>) : option<array<'R>> =
+        let rec go (acc: list<'R>) (rest: list<option<'R>>) : option<list<'R>> =
+            match rest with
+            | [] -> Some acc
+            | None :: _ -> None
+            | Some r :: tail -> go (r :: acc) tail
+
+        Option.map (List.rev >> Array.ofList) (go [] results)
+
+let rec private tryCoerce<'R> (targetType: System.Type) (value: obj) : option<'R> =
+    if targetType.IsInstanceOfType(value) then
+        Some(value :?> 'R)
+    else
+        match value with
+        | :? TomlArray as value when targetType.IsArray ->
+            let elType = targetType.GetElementType()
+
+            let coercedEls =
+                seq { for el in value -> tryCoerce elType el } |> List.ofSeq
+
+            match LookupResult.collect coercedEls with
+            | None -> None
+            | Some array ->
+                // Apparently, one cannot simply cast an object[] with string elements to string[].
+                // What works is creating an instance of an array with the right dynamic type and
+                // then copying all elements to this new array. This feels wrong! There must be a
+                // better way...
+                let castedArray = System.Array.CreateInstance(elType, array.Length)
+                Array.iteri (fun i v -> castedArray.SetValue(v, i)) array
+                Some(box castedArray :?> 'R)
+        | _ -> None
+
+
 let private getFromTable<'R>
     (table: TomlTable)
     (revContext: list<string>)
@@ -24,9 +58,9 @@ let private getFromTable<'R>
         | [ last ] ->
             match table.TryGetValue(last) with
             | true, value ->
-                match value with
-                | :? 'T as value -> Ok value
-                | _ -> Error(WrongType(List.rev (last :: revContext), value, typeof<'T>))
+                match tryCoerce<'R> typeof<'R> value with
+                | Some value -> Ok value
+                | _ -> Error(WrongType(List.rev (last :: revContext), value, typeof<'R>))
             | false, _ -> Error(NotFound(List.rev (last :: revContext)))
         | next :: tail ->
             match table.TryGetValue(next) with
@@ -54,26 +88,43 @@ let private getFromTableOpt<'R> table revSeenPath remPath : Result<option<'R>, L
 /// Note: all config options are laid out flat to make working with the config
 /// without lenses manageable.
 type Config =
-    { caTocEnable: option<bool> }
+    { caTocEnable: option<bool>
+      coreMarkdownExtensions: option<array<string>> }
 
-    static member Default = { caTocEnable = Some true }
+    static member Default =
+        { caTocEnable = Some true
+          coreMarkdownExtensions = Some [| "md"; "markdown" |] }
+
+    static member Empty = { caTocEnable = None; coreMarkdownExtensions = None }
 
     member this.CaTocEnable() =
         this.caTocEnable
-        |> Option.orElse (Config.Default.caTocEnable)
+        |> Option.orElse Config.Default.caTocEnable
+        |> Option.get
+
+    member this.CoreMarkdownExtensions() =
+        this.coreMarkdownExtensions
+        |> Option.orElse Config.Default.coreMarkdownExtensions
         |> Option.get
 
 let private configOfTable (table: TomlTable) : LookupResult<Config> =
     monad {
         let! caTocEnable = getFromTableOpt<bool> table [] [ "code_action"; "toc"; "enable" ]
 
-        { caTocEnable = caTocEnable }
+        let! coreMarkdownExtensions =
+            getFromTableOpt<array<string>> table [] [ "core"; "markdown"; "extensions" ]
+
+        { caTocEnable = caTocEnable
+          coreMarkdownExtensions = coreMarkdownExtensions }
     }
 
 module Config =
     let logger = LogProvider.getLoggerByName "Config"
 
-    let merge hi low = { caTocEnable = hi.caTocEnable |> Option.orElse low.caTocEnable }
+    let merge hi low =
+        { caTocEnable = hi.caTocEnable |> Option.orElse low.caTocEnable
+          coreMarkdownExtensions =
+            hi.coreMarkdownExtensions |> Option.orElse low.coreMarkdownExtensions }
 
     let tryParse (content: string) =
         let mutable table, diag = null, null

--- a/Marksman/Diag.fs
+++ b/Marksman/Diag.fs
@@ -50,7 +50,10 @@ let isCrossFileLink uref =
     | Uref.LinkDef _ -> false
 
 let checkLink (folder: Folder) (doc: Doc) (link: Element) : seq<Entry> =
-    let uref = Uref.ofElement link
+    let configuredExts =
+        (Folder.configOrDefault folder).CoreMarkdownFileExtensions()
+
+    let uref = Uref.ofElement configuredExts link
 
     match uref with
     | None -> []

--- a/Marksman/Misc.fs
+++ b/Marksman/Misc.fs
@@ -1,6 +1,7 @@
 module Marksman.Misc
 
 open System
+open System.IO
 open System.Text
 open System.Text.RegularExpressions
 open Ionide.LanguageServerProtocol.Types
@@ -12,6 +13,17 @@ let flip (f: 'a -> 'b -> 'c) : 'b -> 'a -> 'c = fun b a -> f a b
 let lineEndings = [| "\r\n"; "\n" |]
 
 let concatLines (lines: array<string>) : string = String.concat Environment.NewLine lines
+
+let mkWatchGlob (configuredExts: seq<string>) : string =
+    let ext_pattern = "{" + (String.concat "," (configuredExts)) + "}"
+    $"**/*.{ext_pattern}"
+
+let isMarkdownFile (configuredExts: seq<string>) (path: string) : bool =
+    // GetExtension returns extension with a '.'. In config we don't have '.'s.
+    let ext = (Path.GetExtension path).TrimStart('.')
+    let ext = ext.ToLowerInvariant()
+
+    Seq.contains ext configuredExts
 
 type String with
 

--- a/Marksman/Misc.fs
+++ b/Marksman/Misc.fs
@@ -19,11 +19,20 @@ let mkWatchGlob (configuredExts: seq<string>) : string =
     $"**/*.{ext_pattern}"
 
 let isMarkdownFile (configuredExts: seq<string>) (path: string) : bool =
-    // GetExtension returns extension with a '.'. In config we don't have '.'s.
-    let ext = (Path.GetExtension path).TrimStart('.')
-    let ext = ext.ToLowerInvariant()
+    let isEmacsBackup =
+        try
+            (Path.GetFileName path).StartsWith(".#")
+        with :? ArgumentException ->
+            false
 
-    Seq.contains ext configuredExts
+    if isEmacsBackup then
+        false
+    else
+        // GetExtension returns extension with a '.'. In config we don't have '.'s.
+        let ext = (Path.GetExtension path).TrimStart('.')
+        let ext = ext.ToLowerInvariant()
+
+        Seq.contains ext configuredExts
 
 type String with
 

--- a/Marksman/State.fs
+++ b/Marksman/State.fs
@@ -8,6 +8,7 @@ open FSharpPlus.GenericBuilders
 open Marksman.Diag
 open Marksman.Workspace
 open Marksman.Misc
+open Marksman.Config
 
 type ClientDescription =
     { info: ClientInfo option
@@ -79,6 +80,9 @@ module State =
 
     let workspace s = s.workspace
 
+    let userConfigOrDefault s =
+        Workspace.userConfig s.workspace |> Option.defaultValue Config.Default
+
     let revision s = s.revision
 
     let diag (s: State) = s.Diag()
@@ -116,12 +120,14 @@ module State =
             removed
             |> Array.map (fun f -> PathUri.ofString f.Uri |> FolderId.ofPath)
 
+        let userConfig = workspace state |> Workspace.userConfig
+
         let addedFolders =
             seq {
                 for f in added do
                     let rootUri = RootPath.ofString f.Uri
 
-                    let folder = Folder.tryLoad f.Name rootUri
+                    let folder = Folder.tryLoad userConfig f.Name rootUri
 
                     match folder with
                     | Some folder -> yield folder

--- a/Marksman/Workspace.fsi
+++ b/Marksman/Workspace.fsi
@@ -57,7 +57,7 @@ module Folder =
     val docs: Folder -> seq<Doc>
     val docCount: Folder -> int
 
-    val tryLoad: name: string -> root: RootPath -> option<Folder>
+    val tryLoad: userConfig: option<Config> -> name: string -> root: RootPath -> option<Folder>
 
     val singleFile: doc: Doc -> config: option<Config> -> Folder
     val multiFile: name: string -> root: RootPath -> docs: Map<PathUri, Doc> -> config: option<Config> -> Folder

--- a/Tests/ConfigTests.fs
+++ b/Tests/ConfigTests.fs
@@ -14,7 +14,7 @@ let testParse_0 () =
 
     let actual = Config.tryParse content
 
-    let expected = { caTocEnable = None }
+    let expected = Config.Empty
 
     Assert.Equal(Some expected, actual)
 
@@ -26,7 +26,7 @@ let testParse_1 () =
 """
 
     let actual = Config.tryParse content
-    let expected = { caTocEnable = None }
+    let expected = Config.Empty
     Assert.Equal(Some expected, actual)
 
 [<Fact>]
@@ -39,7 +39,7 @@ toc.enable = false
 
     let actual = Config.tryParse content
 
-    let expected = { caTocEnable = Some false }
+    let expected = { Config.Empty with caTocEnable = Some false }
 
     Assert.Equal(Some expected, actual)
 
@@ -52,10 +52,47 @@ blah
 
     let actual = Config.tryParse content
     Assert.Equal(None, actual)
+    
+[<Fact>]
+let testParse_broken_1 () =
+    let content =
+        """
+[core]
+markdown.extensions = [1, 2]
+"""
+
+    let actual = Config.tryParse content
+    Assert.Equal(None, actual)
+    
+[<Fact>]
+let testParse_broken_2 () =
+    let content =
+        """
+[core]
+markdown.extensions = [["md"], "markdown"]
+"""
+
+    let actual = Config.tryParse content
+    Assert.Equal(None, actual)
+    
+[<Fact>]
+let testParse_broken_3 () =
+    let content =
+        """
+[core]
+markdown.extensions = [["md"], ["markdown"]]
+"""
+
+    let actual = Config.tryParse content
+    Assert.Equal(None, actual)
 
 [<Fact>]
 let testDefault () =
-    let content = Assembly.GetExecutingAssembly().GetManifestResourceStream("default.marksman.toml")
+    let content =
+        Assembly
+            .GetExecutingAssembly()
+            .GetManifestResourceStream("default.marksman.toml")
+
     let content = using (new StreamReader(content)) (fun f -> f.ReadToEnd())
     let parsed = Config.tryParse content
     Assert.Equal(Some Config.Default, parsed)

--- a/Tests/ConfigTests.fs
+++ b/Tests/ConfigTests.fs
@@ -58,7 +58,7 @@ let testParse_broken_1 () =
     let content =
         """
 [core]
-markdown.extensions = [1, 2]
+markdown.file_extensions = [1, 2]
 """
 
     let actual = Config.tryParse content
@@ -69,7 +69,7 @@ let testParse_broken_2 () =
     let content =
         """
 [core]
-markdown.extensions = [["md"], "markdown"]
+markdown.file_extensions = [["md"], "markdown"]
 """
 
     let actual = Config.tryParse content
@@ -80,7 +80,7 @@ let testParse_broken_3 () =
     let content =
         """
 [core]
-markdown.extensions = [["md"], ["markdown"]]
+markdown.file_extensions = [["md"], ["markdown"]]
 """
 
     let actual = Config.tryParse content

--- a/Tests/MiscTests.fs
+++ b/Tests/MiscTests.fs
@@ -61,8 +61,7 @@ module StringExtensionsTests =
         Assert.Equal("/file.md".AbsPathUrlEncodedToRelPath(), "file.md")
 
     [<Fact>]
-    let abspath_urlencode_2 () =
-        Assert.Equal("/file.md", "/file.md".AbsPathUrlEncode())
+    let abspath_urlencode_2 () = Assert.Equal("/file.md", "/file.md".AbsPathUrlEncode())
 
     [<Fact>]
     let abspath_urlencode_3 () =
@@ -73,20 +72,22 @@ module StringExtensionsTests =
     let abspath_urlencode_4 () =
         Assert.Equal("/file%23name.md", "file#name.md".AbsPathUrlEncode())
         Assert.Equal("/file%23name.md".AbsPathUrlEncodedToRelPath(), "file#name.md")
-        
+
     [<Fact>]
     let abspath_urlencode_5 () =
         Assert.Equal("/folder%20name/file%20name.md", "folder name/file name.md".AbsPathUrlEncode())
-        Assert.Equal("/folder%20name/file%20name.md".AbsPathUrlEncodedToRelPath(), "folder name/file name.md")
-        
+
+        Assert.Equal(
+            "/folder%20name/file%20name.md".AbsPathUrlEncodedToRelPath(),
+            "folder name/file name.md"
+        )
+
     [<Fact>]
-    let trimSuffix_1 () =
-        Assert.Equal("foo", "foobar".TrimSuffix("bar"))
-        
+    let trimSuffix_1 () = Assert.Equal("foo", "foobar".TrimSuffix("bar"))
+
     [<Fact>]
-    let trimSuffix_2 () =
-        Assert.Equal("foobar", "foobar".TrimSuffix("baz"))
-    
+    let trimSuffix_2 () = Assert.Equal("foobar", "foobar".TrimSuffix("baz"))
+
 module PathUriTests =
     [<Fact>]
     let testWinPathFromUri () =
@@ -125,3 +126,8 @@ module LinkLabelTest =
     [<Fact>]
     let surroundingWhitespace () =
         Assert.Equal(LinkLabel.ofString "abc", LinkLabel.ofString "  abc ")
+
+module WatchGlobTest =
+    [<Fact>]
+    let test1 () =
+        Assert.Equal("**/*.{md,markdown,mdx}", mkWatchGlob [| "md"; "markdown"; "mdx" |])

--- a/Tests/ParserTests.fs
+++ b/Tests/ParserTests.fs
@@ -293,6 +293,19 @@ module MdLinkTest =
               "MLD: [ref]: https://some.url @ (2,0)-(2,23)"
               "  label=ref @ (2,1)-(2,4); url=https://some.url @ (2,7)-(2,23); title=∅" ]
 
+module FootnoteTests =
+    [<Fact(Skip="Footnote parsing not implemented")>]
+    let footnote_1 () =
+        let text = "[^1]\n\n[^1]: Single line footnote"
+        let document = scrapeString text
+
+        checkInlineSnapshot
+            document
+            [ "ML: [^1] @ (0,0)-(0,4)"
+              "  RS: label=^1 @ (0,1)-(0,3)"
+              "MLD: [^1]: Footnote @ (2,0)-(2,14)"
+              "  label=^1 @ (2,1)-(2,3); url=Footnote @ (2,6)-(2,14); title=∅" ]
+
 module DocUrlTests =
     let mkTextNode str = Node.mkText str (Range.Mk(0, 0, 0, str.Length))
 

--- a/Tests/RefsTests.fs
+++ b/Tests/RefsTests.fs
@@ -126,8 +126,11 @@ let doc2 =
                "[[doc-1]]" // 12
                "[[doc-1#dup]]" // 13
                "[lbl1](/doc1.md)" // 14
-               "" // 15
-               "[d2-link-1]: some-url" |] // 16
+               "[^fn1]" // 15
+               "" // 16
+               "[d2-link-1]: some-url" // 17
+               "" // 18
+               "[^fn1]: This is footnote" |] // 19
     )
 
 let folder = FakeFolder.Mk [ doc1; doc2 ]
@@ -141,7 +144,7 @@ module RefsTests =
     [<Fact>]
     let refToLinkDef_atDef () =
         let def =
-            Cst.elementAtPos (Position.Mk(16, 3)) (Doc.cst doc2)
+            Cst.elementAtPos (Position.Mk(17, 3)) (Doc.cst doc2)
             |> Option.defaultWith (fun _ -> failwith "No def")
 
         let refs = Dest.findElementRefs false folder doc2 def |> stripRefs
@@ -154,7 +157,7 @@ module RefsTests =
     [<Fact>]
     let refToLinkDef_atDef_withDecl () =
         let def =
-            Cst.elementAtPos (Position.Mk(16, 3)) (Doc.cst doc2)
+            Cst.elementAtPos (Position.Mk(17, 3)) (Doc.cst doc2)
             |> Option.defaultWith (fun _ -> failwith "No def")
 
         let refs = Dest.findElementRefs true folder doc2 def |> stripRefs
@@ -162,7 +165,7 @@ module RefsTests =
         checkInlineSnapshot
             (fun x -> x.ToString())
             refs
-            [ "(doc2.md, (16,0)-(16,21))"
+            [ "(doc2.md, (17,0)-(17,21))"
               "(doc2.md, (4,0)-(4,11))"
               "(doc2.md, (8,0)-(8,11))" ]
 
@@ -190,9 +193,22 @@ module RefsTests =
         checkInlineSnapshot
             (fun x -> x.ToString())
             refs
-            [ "(doc2.md, (16,0)-(16,21))"
+            [ "(doc2.md, (17,0)-(17,21))"
               "(doc2.md, (4,0)-(4,11))"
               "(doc2.md, (8,0)-(8,11))" ]
+
+    [<Fact(Skip="Footnote parsing not implemented")>]
+    let refToFootnote_atLink () =
+        let fnLink =
+            Cst.elementAtPos (Position.Mk(15, 2)) (Doc.cst doc2)
+            |> Option.defaultWith (fun _ -> failwith "No def")
+
+        let refs = Dest.findElementRefs true folder doc2 fnLink |> stripRefs
+
+        checkInlineSnapshot
+            (fun x -> x.ToString())
+            refs
+            [ "(doc2.md, (19,0)-(19,16))"; "(doc2.md, (15,0)-(15,6))" ]
 
     [<Fact>]
     let refToDoc_atTitle () =

--- a/Tests/default.marksman.toml
+++ b/Tests/default.marksman.toml
@@ -2,5 +2,8 @@
 # You do not need to duplicate all the values in your own user or project config.
 # Only override what is needed.
 
+[core]
+markdown.extensions = ["md", "markdown"]
+
 [code_action]
 toc.enable = true # Enable/disable "Table of Contents" code action

--- a/Tests/default.marksman.toml
+++ b/Tests/default.marksman.toml
@@ -3,7 +3,7 @@
 # Only override what is needed.
 
 [core]
-markdown.extensions = ["md", "markdown"]
+markdown.file_extensions = ["md", "markdown"]
 
 [code_action]
 toc.enable = true # Enable/disable "Table of Contents" code action

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 ﻿{
   "sdk": {
-    "version": "6.0.300",
+    "version": "6.0.100",
     "rollForward": "latestFeature"
   }
 }


### PR DESCRIPTION
The idea is to allow setting recognized markdown extensions in a config, e.g.
```
[core]
markdown.file_extensions = ["md", "markdown", "mdx", "mdown"]
```

This will resolve #114 

TODO:
* [x] Create a config option
* [x] Wire the config into all the necessary places