### PR TITLE
ci: Add cross-compilation for osx-arm64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,17 +9,23 @@ on:
 
 jobs:
   build:
-    name: Build the release on ${{ matrix.os.runner }}
+    name: Build the release for ${{ matrix.os.rid }}
     runs-on: ${{ matrix.os.runner }}
     strategy:
       matrix:
         os:
           - runner: windows-latest
             exe: marksman.exe
+            rid: win-x64
           - runner: ubuntu-latest
             exe: marksman
+            rid: linux-x64
           - runner: macos-latest
             exe: marksman
+            rid: osx-x64
+          - runner: macos-latest
+            exe: marksman
+            rid: osx-arm64
     steps:
       - uses: actions/checkout@v2
       - name: Setup dotnet
@@ -31,17 +37,17 @@ jobs:
         run: dotnet restore
       
       - name: Build the release binary
-        run: make publishTo DEST=out
+        run: make publishTo DEST=out RID=${{ matrix.os.rid }}
 
       - name: Upload the binary
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ matrix.os.runner }}-${{ matrix.os.exe }}
+          name: ${{ matrix.os.rid }}-${{ matrix.os.exe }}
           path: out/${{ matrix.os.exe }}
           if-no-files-found: error
   
   release:
-    name: Create the release for ${{ matrix.os.runner }}
+    name: Create the release for ${{ matrix.os.rid }}
     needs: build
     runs-on: ${{ matrix.os.runner }}
     strategy:
@@ -49,19 +55,26 @@ jobs:
         os:
           - runner: windows-latest
             exe: marksman.exe
+            rid: win-x64
             release_exe: marksman.exe
           - runner: ubuntu-latest
             exe: marksman
+            rid: linux-x64
             release_exe: marksman-linux
           - runner: macos-latest
             exe: marksman
+            rid: osx-x64
             release_exe: marksman-macos
+          - runner: macos-latest
+            exe: marksman
+            rid: osx-arm64
+            release_exe: marksman-macos-arm64
     steps:
       - id: download
         name: Download the release binary
         uses: actions/download-artifact@v2
         with:
-          name: ${{ matrix.os.runner }}-${{ matrix.os.exe }}
+          name: ${{ matrix.os.rid }}-${{ matrix.os.exe }}
 
       - name: Rename the binary
         shell: python

--- a/Makefile
+++ b/Makefile
@@ -2,43 +2,45 @@
 ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
 $(eval $(ARGS):;@:)
 
-# Do some magic to figure out host's OS and ARCH.
-# This will be used later to build RID for publishing of a self-contained binary.
-OS_ID :=
-ARCH_ID :=
-ifeq ($(OS),Windows_NT)
-    OS_ID := win
-    ifeq ($(PROCESSOR_ARCHITEW6432),AMD64)
-        ARCH_ID := x64
-    else
-        ifeq ($(PROCESSOR_ARCHITECTURE),AMD64)
-            ARCH_ID := x64
-        endif
-        ifeq ($(PROCESSOR_ARCHITECTURE),x86)
-            ARCH_ID := x32
-        endif
-    endif
-else
-    UNAME_S := $(shell uname -s)
-    ifeq ($(UNAME_S),Linux)
-        OS_ID := linux
-    endif
-    ifeq ($(UNAME_S),Darwin)
-        OS_ID := osx
-    endif
-    UNAME_P := $(shell uname -p)
-    ifeq ($(UNAME_P),x86_64)
-        ARCH_ID := x64
-    endif
-    ifneq ($(filter %86,$(UNAME_P)),)
-        ARCH_ID := x64
-    endif
-    ifneq ($(filter arm%,$(UNAME_P)),)
-        ARCH_ID := arm64
-    endif
-endif
+ifndef RID
+	# Do some magic to figure out host's OS and ARCH.
+	# This will be used later to build RID for publishing of a self-contained binary.
+	OS_ID :=
+	ARCH_ID :=
+	ifeq ($(OS),Windows_NT)
+		OS_ID := win
+		ifeq ($(PROCESSOR_ARCHITEW6432),AMD64)
+			ARCH_ID := x64
+		else
+			ifeq ($(PROCESSOR_ARCHITECTURE),AMD64)
+				ARCH_ID := x64
+			endif
+			ifeq ($(PROCESSOR_ARCHITECTURE),x86)
+				ARCH_ID := x32
+			endif
+		endif
+	else
+		UNAME_S := $(shell uname -s)
+		ifeq ($(UNAME_S),Linux)
+			OS_ID := linux
+		endif
+		ifeq ($(UNAME_S),Darwin)
+			OS_ID := osx
+		endif
+		UNAME_P := $(shell uname -p)
+		ifeq ($(UNAME_P),x86_64)
+			ARCH_ID := x64
+		endif
+		ifneq ($(filter %86,$(UNAME_P)),)
+			ARCH_ID := x64
+		endif
+		ifneq ($(filter arm%,$(UNAME_P)),)
+			ARCH_ID := arm64
+		endif
+	endif
 
-RID := $(OS_ID)-$(ARCH_ID)
+	RID := $(OS_ID)-$(ARCH_ID)
+endif
 
 .PHONY: setup
 setup:


### PR DESCRIPTION
Hi, this PR adds a binary for osx-arm64 (M1 Macs) to the release workflow. I tested the build / release process in my own fork, and also downloaded and ran the resulting binary from the release downloads with success. Thanks!