### PR TITLE
ci: add VERSIONSTRING Makefile overwrite parameter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,7 @@ publishTo:
 		-p:PublishTrimmed=true \
 		-p:DebugType=embedded \
 		-p:EnableCompressionInSingleFile=true \
+		-p:VersionString=$(VERSIONSTRING) \
 		Marksman/Marksman.fsproj \
 		-o $(DEST)
 		

--- a/Marksman/Marksman.fsproj
+++ b/Marksman/Marksman.fsproj
@@ -8,7 +8,7 @@
         <EnableLint>false</EnableLint>
     </PropertyGroup>
     <Target Name="Version" BeforeTargets="BeforeBuild">
-        <Exec Command="git describe --always --dirty" ConsoleToMSBuild="true">
+        <Exec Command="git describe --always --dirty" ConsoleToMSBuild="true" Condition="'$(VersionString)'==''">
             <Output TaskParameter="ConsoleOutput" PropertyName="VersionString"/>
         </Exec>
         <PropertyGroup>


### PR DESCRIPTION
The `VERSIONSTRING` parameter for the Makefile is required to be able
to skip the build step that runs `git describe --always --dirty` and
set the version suffix manually.

This change allows the packaging for Homebrew as during the build
process it cannot execute git commands.

This is a optional parameter and will fall back to the git command if
not set specifically.

```bash
make VERSIONSTRING=test DEST=buildir publishTo
```

> Example usage of the parameter, would output a binary with the
> version set to `1.0.0-test`.