### PR TITLE
lsp: Make publishDiagnostics an optional capability

### DIFF
--- a/LanguageServerProtocol/Types.fs
+++ b/LanguageServerProtocol/Types.fs
@@ -747,7 +747,7 @@ type TextDocumentClientCapabilities =
   { Synchronization: SynchronizationCapabilities option
 
     /// Capabilities specific to `textDocument/publishDiagnostics`.
-    PublishDiagnostics: PublishDiagnosticsCapabilities
+    PublishDiagnostics: PublishDiagnosticsCapabilities option
 
     /// Capabilities specific to the `textDocument/completion`
     Completion: CompletionCapabilities option


### PR DESCRIPTION
The spec says it should be an optional property https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocumentClientCapabilities

NOTE: Upstream the fix https://github.com/ionide/LanguageServerProtocol/blob/main/src/Types.fs#L777