### PR TITLE
ci: bump action tasks to newest version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,22 +9,29 @@ on:
 jobs:
   check:
     name: Build on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-    runs-on: ${{ matrix.os }}
+
     steps:
       - uses: actions/checkout@v3
+
       - name: Setup dotnet
-        uses: actions/setup-dotnet@v2
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '6.0.x'
+
       - name: Install dependencies
         run: dotnet restore
+
       - name: Build
         run: dotnet build
+
       - name: Check format and lints
         run: make check
         if: ${{ matrix.os == 'ubuntu-latest' }}
+
       - name: Test with the dotnet CLI
         run: dotnet test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ jobs:
   build:
     name: Build the release for ${{ matrix.os.runner }}
     runs-on: ${{ matrix.os.runner }}
+
     strategy:
       matrix:
         os:
@@ -23,30 +24,34 @@ jobs:
           - runner: macos-latest
             exe: marksman
             task: macosUniversalBinary
+
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+
       - name: Setup dotnet
-        uses: actions/setup-dotnet@v2
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '6.0.x'
-          
+
       - name: Install dependencies
         run: dotnet restore
-      
+
       - name: Build the release binary
         run: make ${{ matrix.os.task }} DEST=out
 
       - name: Upload the binary
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.os.runner }}-${{ matrix.os.exe }}
           path: out/${{ matrix.os.exe }}
           if-no-files-found: error
-  
+
   release:
     name: Create the release for ${{ matrix.os.runner }}
-    needs: build
     runs-on: ${{ matrix.os.runner }}
+
+    needs: build
+
     strategy:
       matrix:
         os:
@@ -59,10 +64,11 @@ jobs:
           - runner: macos-latest
             exe: marksman
             release_exe: marksman-macos
+
     steps:
       - id: download
         name: Download the release binary
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: ${{ matrix.os.runner }}-${{ matrix.os.exe }}
 
@@ -81,4 +87,3 @@ jobs:
           fail_on_unmatched_files: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-


### PR DESCRIPTION
Ensures that no deprecated functionalities are used inside of the workflows.

>  **Note**
> I wasn't able to test these workflows in my own repository since GitHub doesn't allow me to run the workflows there, there aren't any breaking changes in these action tasks that affect your workflows as far as I can tell.

Also as a side not it seems like you forgot to delete the `mac-univ-bin` branch.