### PR TITLE
[compl] Don't encode parentheses in wiki links text

### DIFF
--- a/Marksman/Misc.fs
+++ b/Marksman/Misc.fs
@@ -105,8 +105,7 @@ type String with
         sb.ToString()
 
     member this.EncodeForWiki() : string =
-        let replacement =
-            [| "#", "%23"; "[", "%5B"; "]", "%5D"; "(", "%28"; ")", "%29" |]
+        let replacement = [| "#", "%23"; "[", "%5B"; "]", "%5D" |]
 
         replacement
         |> Array.fold (fun (sb: StringBuilder) -> sb.Replace) (StringBuilder(this))

--- a/Tests/MiscTests.fs
+++ b/Tests/MiscTests.fs
@@ -94,7 +94,7 @@ module StringExtensionsTests =
     [<Fact>]
     let encodeForWiki_2 () =
         let original = "blah #blah [] ()"
-        let expected = "blah %23blah %5B%5D %28%29"
+        let expected = "blah %23blah %5B%5D ()"
         let actual = original.EncodeForWiki()
         Assert.Equal(expected, actual)
         Assert.Equal(original, actual.UrlDecode())


### PR DESCRIPTION
While # and [, ] need to be encoded, ( and ) don't seem to have a special meaning in the context of wiki link contents. Let's allow them as-is for now.