### PR TITLE
docs/install: update package availability for nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,33 +111,9 @@ xattr -d com.apple.quarantine <path-to-marksman-bin>
 brew install marksman
 ```
 
-* Nix
+* Nix, for Linux and MacOS:
 
-`marksman` is available via `nixpkgs`. Currently, it's only available on the `master` branch. You can add it via 
-
-```
-$ nix-channel --add https://github.com/NixOS/nixpkgs/archive/master.tar.gz nixpkgs-master
-```
-
-In your config import the channel at the top 
-
-```nix 
-{ pkgs, ... }:
-let 
-  masterpkgs = import <nixpkgs-master> {};
-in 
-{
- # ...
- # just a simple system wide installation example
- # ...
-  environment.systemPackages = [
-    masterpkgs.marksman
-  ];
- # ...
-}
-```
-
-In the future, it'll be available via the [`unstable`](https://search.nixos.org/packages?channel=unstable&from=0&size=50&sort=relevance&type=packages&query=marksman) channel and eventually via the [`stable`](https://search.nixos.org/packages?channel=22.11&from=0&size=50&sort=relevance&type=packages&query=marksman) channel.
+`marksman` is available [via `nixpkgs`](https://search.nixos.org/packages?query=marksman).
 
 ## Demo
 


### PR DESCRIPTION
The package is now available on the stable channel;
It is no longer necessary to manually import from the master branch.
This also clarifies that it works for both Linux and MacOS too.
