### PR TITLE
core: Die with a helpful message when an exception is raised in state update

### DIFF
--- a/Marksman/Fatality.fs
+++ b/Marksman/Fatality.fs
@@ -1,0 +1,42 @@
+module Marksman.Fatality
+
+open Ionide.LanguageServerProtocol.Types
+open Marksman.State
+open Marksman.Workspace
+
+let abort (stateOpt: Option<State>) (ex: exn) =
+    let marksmanAssembly = typeof<State>.Assembly.GetName ()
+
+    let clientDebugOut ({ Name = name; Version = versionOpt }: ClientInfo) =
+        eprintf $"Client: {name}"
+        Option.iter (fun v -> eprintf $"{v}") versionOpt
+        eprintfn ""
+
+    let stateDebugOut (state: State) =
+        Option.iter clientDebugOut (State.client state).info
+        let workspace = State.workspace state
+        let stateRevision = State.revision state
+
+        let userConfigString =
+            if Option.isSome (Workspace.userConfig workspace) then
+                "present"
+            else
+                "absent"
+
+        eprintfn "Workspace:"
+        eprintfn $"  Revision      : {stateRevision}"
+        eprintfn $"  Folder count  : {Workspace.folderCount workspace}"
+        eprintfn $"  Document count: {Workspace.folderCount workspace}"
+        eprintfn $"  User config   : {userConfigString}"
+
+    eprintfn "---------------------------------------------------------------------------"
+    eprintfn "Marksman encountered a fatal error"
+    eprintfn "Please, report the error at https://github.com/artempyanykh/marksman/issues"
+    eprintfn "---------------------------------------------------------------------------"
+    eprintfn $"Marksman version: {marksmanAssembly.Version}"
+    eprintfn $"OS: {System.Runtime.InteropServices.RuntimeInformation.OSDescription}"
+    eprintfn $"Arch: {System.Runtime.InteropServices.RuntimeInformation.OSArchitecture}"
+    Option.iter stateDebugOut stateOpt
+    eprintfn "---------------------------------------------------------------------------"
+    eprintfn $"{ex.ToString()}"
+    exit 1

--- a/Marksman/Marksman.fsproj
+++ b/Marksman/Marksman.fsproj
@@ -37,6 +37,7 @@
         <Compile Include="Refs.fs"/>
         <Compile Include="Diag.fs"/>
         <Compile Include="State.fs"/>
+        <Compile Include="Fatality.fs"/>
         <Compile Include="Toc.fs"/>
         <Compile Include="CodeActions.fs"/>
         <Compile Include="Compl.fs"/>

--- a/Marksman/Misc.fs
+++ b/Marksman/Misc.fs
@@ -6,8 +6,6 @@ open System.Text
 open System.Text.RegularExpressions
 open Ionide.LanguageServerProtocol.Types
 
-let todo what = failwith $"{what} not implemented"
-
 let flip (f: 'a -> 'b -> 'c) : 'b -> 'a -> 'c = fun b a -> f a b
 
 let lineEndings = [| "\r\n"; "\n" |]

--- a/Marksman/Server.fs
+++ b/Marksman/Server.fs
@@ -372,7 +372,12 @@ type StateManager(initState: State) =
                         chan.Reply state
                         return! go prevState state hooks
                     | MutateState mutator ->
-                        let newState, addedHooks = mutator state
+                        let newState, addedHooks =
+                            try
+                                mutator state
+                            with ex ->
+                                // Failing to update a state is a fatal error. We should crash
+                                Fatality.abort (Some state) ex
 
                         // Step 1: run _added_ hooks on the existing state
 

--- a/Marksman/State.fs
+++ b/Marksman/State.fs
@@ -92,7 +92,7 @@ module State =
 
     let findFolderEnclosing (uri: PathUri) (state: State) : Folder =
         tryFindFolderEnclosing uri state
-        |> Option.defaultWith (fun _ -> failwith $"Expected folder now found: {uri}")
+        |> Option.defaultWith (fun _ -> failwith $"Expected folder not found: {uri}")
 
     let tryFindFolderAndDoc (uri: PathUri) (state: State) : option<Folder * Doc> =
         tryFindFolderEnclosing uri state

--- a/Marksman/Workspace.fs
+++ b/Marksman/Workspace.fs
@@ -476,3 +476,5 @@ module Workspace =
 
     let docCount (workspace: Workspace) : int =
         workspace.folders.Values |> Seq.sumBy Folder.docCount
+
+    let folderCount (workspace: Workspace) : int = workspace.folders.Count

--- a/Marksman/Workspace.fsi
+++ b/Marksman/Workspace.fsi
@@ -76,6 +76,7 @@ type Workspace
 
 module Workspace =
     val folders: Workspace -> seq<Folder>
+    val folderCount: Workspace -> int
     val docCount: Workspace -> int
     val userConfig: Workspace -> option<Config>
 

--- a/scripts/marksman-server.sh
+++ b/scripts/marksman-server.sh
@@ -4,4 +4,4 @@ SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 TOP_DIR="$SCRIPT_DIR/.."
 make -C "$TOP_DIR" build </dev/null 1>&2
 
-exec "$TOP_DIR/Marksman/bin/Debug/net6.0/marksman" "${@:1}"
+exec "$TOP_DIR/Marksman/bin/Debug/net6.0/marksman" "${@:1}" server -v=4


### PR DESCRIPTION
Summary:
Marksman core doesn't use exceptions for regular control flow so any
exception originating in the core is basically an assert violation.

Outside of server bugs one potential source of exceptions in core is
bugs in clients (e.g. incremental text sync).

Previously, such exception would cause a thread die a silent death in
the guts of async, followed by the process dying because of the timeout
on async response.

This is not helpful because the original exception gets lost, so good
luck debugging what was wrong.

Now the process will just die right away but it'll output a helpful
message together with the original exception, which makes debugging so
much easier.

Example of a message:
```
---------------------------------------------------------------------------
Marksman encountered a fatal error
Please, report the error at https://github.com/artempyanykh/marksman/issues
---------------------------------------------------------------------------
Marksman version: 1.0.0.0
OS: Darwin 22.3.0 Darwin Kernel Version 22.3.0: Mon Jan 30 20:38:37 PST 2023; root:xnu-8792.81.3~2/RELEASE_ARM64_T6000
Arch: Arm64
Client: emacsGNU Emacs 28.2 (build 1, aarch64-apple-darwin22.2.0, Carbon Version 169 AppKit 2299.3)
 of 2023-02-12
Workspace:
  Revision      : 1
  Folder count  : 1
  Document count: 1
  User config   : absent
---------------------------------------------------------------------------
System.Exception: Position outside of line map: (4,11)
   at Marksman.Text.FindOffset@58.Invoke(Unit _arg2) in /Users/arr/dev/marksman/Marksman/Text.fs:line 58
   at Marksman.Text.LineMap.FindOffset(Position pos) in /Users/arr/dev/marksman/Marksman/Text.fs:line 58
   at Marksman.Text.applyChangeOne(Text text, TextDocumentContentChangeEvent change) in /Users/arr/dev/marksman/Marksman/Text.fs:line 188
   at Marksman.Text.applyTextChange@202.Invoke(Text text, TextDocumentContentChangeEvent change)
   at Microsoft.FSharp.Collections.ArrayModule.Fold[T,TState](FSharpFunc`2 folder, TState state, T[] array) in D:\a\_work\1\s\src\fsharp\FSharp.Core\array.fs:line 901
   at Marksman.Text.applyTextChange(TextDocumentContentChangeEvent[] changeEvents, Text text) in /Users/arr/dev/marksman/Marksman/Text.fs:line 202
   at Marksman.Workspace.DocModule.applyLspChange(DidChangeTextDocumentParams change, Doc doc) in /Users/arr/dev/marksman/Marksman/Workspace.fs:line 87
   at Marksman.Server.TextDocumentDidChange@569.Invoke(State state) in /Users/arr/dev/marksman/Marksman/Server.fs:line 575
   at Marksman.Server.mutator@423.Invoke(State state) in /Users/arr/dev/marksman/Marksman/Server.fs:line 423
   at Marksman.Server.go@366-6.Invoke(StateMessage _arg1) in /Users/arr/dev/marksman/Marksman/Server.fs:line 377

Process marksman stderr finished
```
