### PR TITLE
[core] Make text sync configurable and use full by default

### DIFF
--- a/Tests/ConfigTests.fs
+++ b/Tests/ConfigTests.fs
@@ -42,7 +42,7 @@ toc.enable = false
     let expected = { Config.Empty with caTocEnable = Some false }
 
     Assert.Equal(Some expected, actual)
-    
+
 
 [<Fact>]
 let testParse_3 () =
@@ -55,6 +55,20 @@ wiki.style = "file-stem"
     let actual = Config.tryParse content
 
     let expected = { Config.Empty with complWikiStyle = Some FileStem }
+
+    Assert.Equal(Some expected, actual)
+
+[<Fact>]
+let testParse_4 () =
+    let content =
+        """
+[core]
+text_sync = "incremental"
+"""
+
+    let actual = Config.tryParse content
+
+    let expected = { Config.Empty with coreTextSync = Some Incremental }
 
     Assert.Equal(Some expected, actual)
 

--- a/Tests/default.marksman.toml
+++ b/Tests/default.marksman.toml
@@ -4,6 +4,7 @@
 
 [core]
 markdown.file_extensions = ["md", "markdown"]
+text_sync = "full"
 
 [code_action]
 toc.enable = true # Enable/disable "Table of Contents" code action


### PR DESCRIPTION
Incremental text sync is more efficient but has been problematic
historically due to client bugs and protocol lacking necessary
information to enforce stronger validation on the server side.

The option to choose incremental text sync is still there, but the
default now is 'full' where the client is expected to send the full
contents of the document on every change.
