### PR TITLE
client: Allow clients to specify preferred text sync kind

### DIFF
--- a/Tests/ServerTests.fs
+++ b/Tests/ServerTests.fs
@@ -1,0 +1,44 @@
+module Marksman.ServerTests
+
+open Xunit
+
+open Marksman.Config
+open Marksman.State
+open Marksman.Workspace
+open Marksman.Server
+
+open Marksman.Helpers
+
+module ServerUtilTests =
+    [<Fact>]
+    let textSync_UserConfigEmptyWS () =
+        let c = {Config.Default with coreTextSync = Some Incremental }
+        let clientDesc = ClientDescription.empty 
+        let ws = Workspace.ofFolders (Some c) []
+        Assert.Equal(("userConfig", Incremental), ServerUtil.calcTextSync (Some c) ws clientDesc)
+        
+    [<Fact>]
+    let textSync_NoConfigEmptyWS () =
+        let clientDesc = ClientDescription.empty 
+        let ws = Workspace.ofFolders None []
+        Assert.Equal(("default", Full), ServerUtil.calcTextSync None ws clientDesc)
+        
+    [<Fact>]
+    let textSync_NoConfigEmptyWS_PreferIncr () =
+        let clientDesc = {ClientDescription.empty with opts = {preferredTextSyncKind = Some Incremental }}
+        let ws = Workspace.ofFolders None []
+        Assert.Equal(("clientOption", Incremental), ServerUtil.calcTextSync None ws clientDesc)
+        
+    [<Fact>]
+    let textSync_NoConfigNonEmptyWS_PreferIncr () =
+        let clientDesc = {ClientDescription.empty with opts = {preferredTextSyncKind = Some Incremental }}
+        let folder = Folder.multiFile "test" (dummyRootPath ["test"] |> RootPath.ofString) Map.empty None
+        let ws = Workspace.ofFolders None [folder]
+        Assert.Equal(("clientOption", Incremental), ServerUtil.calcTextSync None ws clientDesc)
+        
+    [<Fact>]
+    let textSync_NonEmptyWS_PreferIncrButConfigTakesPrecedence () =
+        let clientDesc = {ClientDescription.empty with opts = {preferredTextSyncKind = Some Incremental }}
+        let folder = Folder.multiFile "test" (dummyRootPath ["test"] |> RootPath.ofString) Map.empty (Some {Config.Empty with coreTextSync = Some Full })
+        let ws = Workspace.ofFolders None [folder]
+        Assert.Equal(("workspaceConfig", Full), ServerUtil.calcTextSync None ws clientDesc)

--- a/Tests/StateTests.fs
+++ b/Tests/StateTests.fs
@@ -1,0 +1,33 @@
+module Marsman.ServerTests
+
+open Newtonsoft.Json.Linq
+open Xunit
+
+open Marksman
+open Marksman.State
+
+module InitOptionTests =
+    [<Fact>]
+    let extractEmpty () =
+        let json = JToken.Parse("{}")
+        Assert.Equal(InitOptions.empty, InitOptions.ofJson json)
+        
+        let json = JToken.Parse("[]")
+        Assert.Equal(InitOptions.empty, InitOptions.ofJson json)
+        
+    [<Fact>]
+    let extractCorrect () =
+        let json = JToken.Parse("""{"preferredTextSyncKind": 1}""")
+        Assert.Equal({preferredTextSyncKind = Some Config.Full}, InitOptions.ofJson json)
+        
+        let json = JToken.Parse("""{"preferredTextSyncKind": 2}""")
+        Assert.Equal({preferredTextSyncKind = Some Config.Incremental}, InitOptions.ofJson json)
+        
+    [<Fact>]
+    let extractMalformed () =
+        let json = JToken.Parse("""{"preferredTextSyncKind": 42}""")
+        Assert.Equal({preferredTextSyncKind = None}, InitOptions.ofJson json)
+        
+        let json = JToken.Parse("""{"preferredTextSyncKind": "full"}""")
+        Assert.Equal({preferredTextSyncKind = None}, InitOptions.ofJson json)
+

--- a/Tests/Tests.fsproj
+++ b/Tests/Tests.fsproj
@@ -8,32 +8,34 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <Compile Include="Helpers.fs" />
-        <Compile Include="ParserTests.fs" />
-        <Compile Include="TextTests.fs" />
-        <Compile Include="MiscTests.fs" />
-        <Compile Include="DiagTest.fs" />
-        <Compile Include="ComplTests.fs" />
-        <Compile Include="SematoTests.fs" />
-        <Compile Include="WorkspaceTest.fs" />
-        <Compile Include="TocTests.fs" />
-        <Compile Include="RefsTests.fs" />
-        <Compile Include="RefactorTests.fs" />
-        <Compile Include="SymbolsTests.fs" />
-        <Compile Include="ConfigTests.fs" />
-        <Compile Include="GitIgnoreTest.fs" />
-        <Compile Include="Program.fs" />
-    </ItemGroup>
-    
-    <ItemGroup>
-        <EmbeddedResource Include="default.marksman.toml" LogicalName="default.marksman.toml" />
+        <Compile Include="Helpers.fs"/>
+        <Compile Include="ParserTests.fs"/>
+        <Compile Include="TextTests.fs"/>
+        <Compile Include="MiscTests.fs"/>
+        <Compile Include="DiagTest.fs"/>
+        <Compile Include="ComplTests.fs"/>
+        <Compile Include="SematoTests.fs"/>
+        <Compile Include="WorkspaceTest.fs"/>
+        <Compile Include="TocTests.fs"/>
+        <Compile Include="RefsTests.fs"/>
+        <Compile Include="RefactorTests.fs"/>
+        <Compile Include="SymbolsTests.fs"/>
+        <Compile Include="ConfigTests.fs"/>
+        <Compile Include="GitIgnoreTest.fs"/>
+        <Compile Include="StateTests.fs"/>
+        <Compile Include="ServerTests.fs"/>
+        <Compile Include="Program.fs"/>
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
-        <PackageReference Update="FSharp.Core" Version="6.0.5" />
-        <PackageReference Include="Snapper" Version="2.3.2" />
-        <PackageReference Include="xunit" Version="2.4.2" />
+        <EmbeddedResource Include="default.marksman.toml" LogicalName="default.marksman.toml"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0"/>
+        <PackageReference Update="FSharp.Core" Version="6.0.5"/>
+        <PackageReference Include="Snapper" Version="2.3.2"/>
+        <PackageReference Include="xunit" Version="2.4.2"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
@@ -45,7 +47,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\Marksman\Marksman.fsproj" />
+        <ProjectReference Include="..\Marksman\Marksman.fsproj"/>
     </ItemGroup>
 
 </Project>

--- a/scripts/marksman-server.bat
+++ b/scripts/marksman-server.bat
@@ -1,4 +1,4 @@
 ﻿@ECHO OFF
 SET rootDir=%~dp0..
 make -C %rootDir% build
-%rootDir%\Marksman\bin\Debug\net6.0\marksman.exe
+%rootDir%\Marksman\bin\Debug\net7.0\marksman.exe

--- a/scripts/marksman-server.sh
+++ b/scripts/marksman-server.sh
@@ -4,4 +4,4 @@ SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 TOP_DIR="$SCRIPT_DIR/.."
 make -C "$TOP_DIR" build </dev/null 1>&2
 
-exec "$TOP_DIR/Marksman/bin/Debug/net6.0/marksman" "${@:1}" server -v=4
+exec "$TOP_DIR/Marksman/bin/Debug/net7.0/marksman" "${@:1}" server -v=4


### PR DESCRIPTION
Marksman allows users configure text sync kind in their config. With no
config marksman defaults to Full text sync. Some clients (e.g. ST) would
like a different default. Now such clients can supply it as part of
initialization options:
```
{
  "preferredTextSyncKind": 1|2
}
```

This option has lower precedence than whatever user configures in their
global/workspace-local config file.
