### PR TITLE
perf: Speed up cross-file link resolution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ Marksman.sln.DotSettings.user
 **/obj
 
 .fake
+
+BenchmarkDotNet.Artifacts

--- a/Benchmarks/Benchmarks.fsproj
+++ b/Benchmarks/Benchmarks.fsproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net7.0</TargetFramework>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <Compile Include="Program.fs" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Include="BenchmarkDotNet" Version="0.13.5" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Marksman\Marksman.fsproj" />
+    </ItemGroup>
+
+</Project>

--- a/Benchmarks/Program.fs
+++ b/Benchmarks/Program.fs
@@ -1,0 +1,93 @@
+﻿module Marksman.Benchmark
+
+open BenchmarkDotNet.Attributes
+open BenchmarkDotNet.Running
+
+open Ionide.LanguageServerProtocol.Types
+
+open Marksman.Misc
+open Marksman.Paths
+open Marksman.Workspace
+open Marksman.Index
+open Marksman.Refs
+open Marksman.Cst
+
+type ReferenceResolution() =
+    let mkFolder size : Folder =
+        let folderRoot =
+            (if isWindows then "C:\\docs" else "/docs") |> AbsPath.ofSystem
+
+        let folderId =
+            let uri = folderRoot |> AbsPath.toUri
+            UriWith.mkRoot uri
+
+        let docs =
+            Array.init size (fun i ->
+                let docId = UriWith.mkRooted folderId (LocalPath.ofSystem $"doc{i}.md")
+                let links = List.init size (fun toDoc -> $"[[doc{toDoc}.md]]")
+                let contentLines = $"# Doc {i}" :: links
+                let content = String.concat "\n" contentLines
+                let text = Text.mkText content
+                let doc = Doc.mk docId None text
+                doc.Id.data.path, doc)
+
+        let docs = Map.ofArray docs
+        Folder.multiFile "docs" folderId docs None
+
+    [<Params(10, 50, 250)>]
+    member val public FolderSize: int = 10 with get, set
+
+    member val public Folder: Folder = mkFolder 10 with get, set
+
+    [<GlobalSetup>]
+    member this.setup() = this.Folder <- mkFolder this.FolderSize
+
+    [<Benchmark>]
+    member this.gotoDefTime() =
+        let doc =
+            Folder.tryFindDocByRelPath (RelPath "doc1.md") this.Folder
+            |> Option.get
+
+        let link =
+            Doc.index doc |> Index.linkAtPos (Position.Mk(1, 3)) |> Option.get
+
+        let uref = Uref.ofElement [| "md" |] doc.Id link |> Option.get
+        let refs = Dest.tryResolveUref uref doc this.Folder |> Seq.toArray
+        refs |> ignore
+
+    [<Benchmark>]
+    member this.findRefsTime() =
+        let doc =
+            Folder.tryFindDocByRelPath (RelPath "doc1.md") this.Folder
+            |> Option.get
+
+        let header =
+            Cst.elementAtPos (Position.Mk(0, 3)) (Doc.cst doc) |> Option.get
+
+        let refs = Dest.findElementRefs true this.Folder doc header |> Seq.toArray
+        refs |> ignore
+
+
+[<EntryPoint>]
+let main _ =
+    // Uncomment to debug the benchmark routines
+    // ReferenceResolution().gotoDefTime()
+    // ReferenceResolution().findRefsTime()
+    BenchmarkRunner.Run<ReferenceResolution>() |> ignore
+    0
+
+// BenchmarkDotNet=v0.13.5, OS=macOS Ventura 13.3.1 (22E261) [Darwin 22.4.0]
+// Apple M1 Pro, 1 CPU, 10 logical and 10 physical cores
+// .NET SDK=7.0.302
+//   [Host]     : .NET 7.0.5 (7.0.523.17405), Arm64 RyuJIT AdvSIMD DEBUG
+//   DefaultJob : .NET 7.0.5 (7.0.523.17405), Arm64 RyuJIT AdvSIMD
+//
+//
+// |       Method | FolderSize |             Mean |        Error |       StdDev |
+// |------------- |----------- |-----------------:|-------------:|-------------:|
+// |  gotoDefTime |         10 |         12.69 us |     0.021 us |     0.019 us |
+// | findRefsTime |         10 |      1,392.42 us |     2.681 us |     2.377 us |
+// |  gotoDefTime |         50 |         62.92 us |     0.078 us |     0.073 us |
+// | findRefsTime |         50 |    164,905.21 us |   229.081 us |   214.283 us |
+// |  gotoDefTime |        250 |        319.72 us |     0.575 us |     0.510 us |
+// | findRefsTime |        250 | 20,683,207.26 us | 6,810.020 us | 6,036.905 us |

--- a/Benchmarks/Program.fs
+++ b/Benchmarks/Program.fs
@@ -28,10 +28,8 @@ type ReferenceResolution() =
                 let contentLines = $"# Doc {i}" :: links
                 let content = String.concat "\n" contentLines
                 let text = Text.mkText content
-                let doc = Doc.mk docId None text
-                doc.Id.data.path, doc)
+                Doc.mk docId None text)
 
-        let docs = Map.ofArray docs
         Folder.multiFile "docs" folderId docs None
 
     [<Params(10, 50, 250)>]
@@ -79,15 +77,15 @@ let main _ =
 // BenchmarkDotNet=v0.13.5, OS=macOS Ventura 13.3.1 (22E261) [Darwin 22.4.0]
 // Apple M1 Pro, 1 CPU, 10 logical and 10 physical cores
 // .NET SDK=7.0.302
-//   [Host]     : .NET 7.0.5 (7.0.523.17405), Arm64 RyuJIT AdvSIMD DEBUG
+//   [Host]     : .NET 7.0.5 (7.0.523.17405), Arm64 RyuJIT AdvSIMD DEBUG [AttachedDebugger]
 //   DefaultJob : .NET 7.0.5 (7.0.523.17405), Arm64 RyuJIT AdvSIMD
 //
 //
-// |       Method | FolderSize |             Mean |        Error |       StdDev |
-// |------------- |----------- |-----------------:|-------------:|-------------:|
-// |  gotoDefTime |         10 |         12.69 us |     0.021 us |     0.019 us |
-// | findRefsTime |         10 |      1,392.42 us |     2.681 us |     2.377 us |
-// |  gotoDefTime |         50 |         62.92 us |     0.078 us |     0.073 us |
-// | findRefsTime |         50 |    164,905.21 us |   229.081 us |   214.283 us |
-// |  gotoDefTime |        250 |        319.72 us |     0.575 us |     0.510 us |
-// | findRefsTime |        250 | 20,683,207.26 us | 6,810.020 us | 6,036.905 us |
+// |       Method | FolderSize |           Mean |       Error |      StdDev |
+// |------------- |----------- |---------------:|------------:|------------:|
+// |  gotoDefTime |         10 |       1.180 us |   0.0034 us |   0.0032 us |
+// | findRefsTime |         10 |     147.967 us |   0.7200 us |   0.6735 us |
+// |  gotoDefTime |         50 |       1.294 us |   0.0013 us |   0.0011 us |
+// | findRefsTime |         50 |   4,040.372 us |   4.7052 us |   4.4013 us |
+// |  gotoDefTime |        250 |       1.433 us |   0.0022 us |   0.0019 us |
+// | findRefsTime |        250 | 115,387.334 us | 118.0649 us | 104.6614 us |

--- a/Makefile
+++ b/Makefile
@@ -82,10 +82,15 @@ clean:
 run:
 	dotnet run --project Marksman -- $(ARGS)
 
+.PHONY: bench
+bench:
+	dotnet run -c Release --project Benchmarks -- $(ARGS)
+
 .PHONY: fmt
 fmt: setup
 	dotnet fantomas Marksman
 	dotnet fantomas Tests
+	dotnet fantomas Benchmarks
 ifneq ($(OS_ID),win)
 	xmllint Marksman/Marksman.fsproj -o Marksman/Marksman.fsproj
 endif

--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,10 @@ check: setup
 build:
 	dotnet build Marksman/Marksman.fsproj
 
+.PHONY: test
+test:
+	dotnet test
+
 .PHONY: clean
 clean:
 	dotnet clean

--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,7 @@ run:
 .PHONY: fmt
 fmt: setup
 	dotnet fantomas Marksman
+	dotnet fantomas Tests
 ifneq ($(OS_ID),win)
 	xmllint Marksman/Marksman.fsproj -o Marksman/Marksman.fsproj
 endif

--- a/Marksman.sln
+++ b/Marksman.sln
@@ -8,6 +8,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MarkdigPatches", "MarkdigPa
 EndProject
 Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "LanguageServerProtocol", "LanguageServerProtocol\LanguageServerProtocol.fsproj", "{0818D3FB-F6FA-4C0F-B681-8BCB03680562}"
 EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Benchmarks", "Benchmarks\Benchmarks.fsproj", "{4A518AAD-F243-41A8-A999-D44031DF587C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -30,5 +32,9 @@ Global
 		{0818D3FB-F6FA-4C0F-B681-8BCB03680562}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0818D3FB-F6FA-4C0F-B681-8BCB03680562}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0818D3FB-F6FA-4C0F-B681-8BCB03680562}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4A518AAD-F243-41A8-A999-D44031DF587C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4A518AAD-F243-41A8-A999-D44031DF587C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4A518AAD-F243-41A8-A999-D44031DF587C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4A518AAD-F243-41A8-A999-D44031DF587C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/Marksman/Compl.fs
+++ b/Marksman/Compl.fs
@@ -330,7 +330,7 @@ module CompletionHelpers =
             let name = docPath |> RelPath.filenameStem
             WPath(Approx(RelPath name))
         | FilePathStem ->
-            let name = docPath |> RelPath.filepathStem
+            let (PathStem name) = docPath |> RelPath.filepathStem
             WPath(ExactAbs(RootedRelPath.mk (Doc.rootPath doc) (Rel name)))
 
 module Completions =

--- a/Marksman/Compl.fs
+++ b/Marksman/Compl.fs
@@ -1,20 +1,19 @@
 ﻿module Marksman.Compl
 
 open System
-
 open System.IO
+open FSharpPlus.GenericBuilders
 open Ionide.LanguageServerProtocol.Logging
 open Ionide.LanguageServerProtocol.Types
-
-open FSharpPlus.GenericBuilders
 
 open Marksman.Config
 open Marksman.Cst
 open Marksman.Index
-open Marksman.Refs
-open Marksman.Workspace
 open Marksman.Misc
+open Marksman.Paths
+open Marksman.Refs
 open Marksman.Text
+open Marksman.Workspace
 
 let private logger = LogProvider.getLoggerByName "Compl"
 

--- a/Marksman/Config.fs
+++ b/Marksman/Config.fs
@@ -1,8 +1,8 @@
 module Marksman.Config
 
-open System.IO
 open FSharpPlus
 open Ionide.LanguageServerProtocol.Logging
+open System.IO
 open Tomlyn
 open Tomlyn.Model
 

--- a/Marksman/Cst.fs
+++ b/Marksman/Cst.fs
@@ -7,6 +7,7 @@ open Ionide.LanguageServerProtocol.Types
 
 open Marksman.Misc
 open Marksman.Names
+open Marksman.Paths
 
 type Node<'A> = { text: string; range: Range; data: 'A }
 
@@ -33,6 +34,18 @@ module Node =
 
 [<RequireQualifiedAccess>]
 type WikiLink = { doc: option<WikiEncodedNode>; heading: option<WikiEncodedNode> }
+
+type WikiDest =
+    | WTitle of string
+    | WPath of InternPath
+
+module WikiDest =
+    let encode wd =
+        match wd with
+        | WTitle t -> WikiEncoded.encode t
+        | WPath p ->
+            let relPath = (InternPath.toRel >> RelPath.toSystem) p
+            relPath.EncodePathForWiki() |> WikiEncoded.mkUnchecked
 
 module WikiLink =
     let destDoc (dest: WikiLink) : option<WikiEncoded> = dest.doc |> Option.map Node.data

--- a/Marksman/Cst.fs
+++ b/Marksman/Cst.fs
@@ -57,9 +57,12 @@ module WikiLink =
         : string =
         let docText = doc |> Option.map WikiEncoded.raw |> Option.defaultValue ""
 
+        let renderHeading h = "#" + (WikiEncoded.raw h)
+
         let headingText =
             heading
-            |> Option.map (fun h -> "#" + (WikiEncoded.raw h))
+            |> Option.map renderHeading
+
             |> Option.defaultValue ""
 
         let linkText = $"{docText}{headingText}"

--- a/Marksman/Cst.fs
+++ b/Marksman/Cst.fs
@@ -2,9 +2,8 @@
 
 open System
 
-open Ionide.LanguageServerProtocol.Types
-
 open FSharpPlus.Operators
+open Ionide.LanguageServerProtocol.Types
 
 open Marksman.Misc
 

--- a/Marksman/Diag.fs
+++ b/Marksman/Diag.fs
@@ -1,14 +1,15 @@
 module Marksman.Diag
 
-open System.IO
 open Ionide.LanguageServerProtocol.Types
+
 open Marksman.Workspace
+open Marksman.Paths
 
 module Lsp = Ionide.LanguageServerProtocol.Types
 
-open Marksman.Misc
 open Marksman.Cst
 open Marksman.Index
+open Marksman.Misc
 open Marksman.Refs
 
 type Entry =

--- a/Marksman/Fatality.fs
+++ b/Marksman/Fatality.fs
@@ -1,6 +1,7 @@
 module Marksman.Fatality
 
 open Ionide.LanguageServerProtocol.Types
+
 open Marksman.State
 open Marksman.Workspace
 

--- a/Marksman/GitIgnore.fs
+++ b/Marksman/GitIgnore.fs
@@ -3,7 +3,6 @@ module Marksman.GitIgnore
 open System
 open System.IO
 open GlobExpressions
-open Marksman.Misc
 
 type GlobPattern =
     | Include of Glob

--- a/Marksman/Index.fs
+++ b/Marksman/Index.fs
@@ -1,8 +1,9 @@
 module Marksman.Index
 
 open Ionide.LanguageServerProtocol.Types
-open Marksman.Misc
+
 open Marksman.Cst
+open Marksman.Misc
 
 type Dictionary<'K, 'V> = System.Collections.Generic.Dictionary<'K, 'V>
 

--- a/Marksman/Marksman.fsproj
+++ b/Marksman/Marksman.fsproj
@@ -27,6 +27,8 @@
         <Compile Include="Misc.fs"/>
         <Compile Include="Paths.fsi"/>
         <Compile Include="Paths.fs"/>
+        <Compile Include="Names.fsi"/>
+        <Compile Include="Names.fs"/>
         <Compile Include="GitIgnore.fs"/>
         <Compile Include="Config.fs"/>
         <Compile Include="Text.fs"/>

--- a/Marksman/Marksman.fsproj
+++ b/Marksman/Marksman.fsproj
@@ -25,6 +25,8 @@
     </Target>
     <ItemGroup>
         <Compile Include="Misc.fs"/>
+        <Compile Include="Paths.fsi"/>
+        <Compile Include="Paths.fs"/>
         <Compile Include="GitIgnore.fs"/>
         <Compile Include="Config.fs"/>
         <Compile Include="Text.fs"/>

--- a/Marksman/Misc.fs
+++ b/Marksman/Misc.fs
@@ -4,6 +4,7 @@ open System
 open System.IO
 open System.Text
 open System.Text.RegularExpressions
+
 open Ionide.LanguageServerProtocol.Types
 
 let flip (f: 'a -> 'b -> 'c) : 'b -> 'a -> 'c = fun b a -> f a b
@@ -181,87 +182,6 @@ let indentFmt (fmtA: 'A -> string) (a: 'A) =
 
     String.Join(Environment.NewLine, indentedLines)
 
-[<CustomEquality; CustomComparison>]
-type PathUri =
-    private
-        { uri: string
-          localPath: string }
-
-    member this.DocumentUri: string = this.uri
-
-    member this.LocalPath: string = this.localPath
-
-    override this.Equals(obj) =
-        match obj with
-        | :? PathUri as other -> this.LocalPath.Equals(other.LocalPath)
-        | _ -> false
-
-
-    override this.GetHashCode() = this.LocalPath.GetHashCode()
-
-    interface IComparable with
-        member this.CompareTo(obj) =
-            match obj with
-            | :? PathUri as other -> this.LocalPath.CompareTo(other.LocalPath)
-            | _ -> failwith "Incompatible Type"
-
-
-// https://github.dev/fsharp/FsAutoComplete/blob/d90597c2e073b7e88390f2b1933b031ff8a9a009/src/FsAutoComplete.Core/Utils.fs#L635
-let localPathToUriString (filePath: string) : string =
-    let uri = StringBuilder(filePath.Length)
-
-    for c in filePath do
-        if
-            (c >= 'a' && c <= 'z')
-            || (c >= 'A' && c <= 'Z')
-            || (c >= '0' && c <= '9')
-            || c = '+'
-            || c = '/'
-            || c = '.'
-            || c = '-'
-            || c = '_'
-            || c = '~'
-            || c > '\xFF'
-        then
-            uri.Append(c) |> ignore
-        // handle windows path separator chars.
-        // we _would_ use Path.DirectorySeparator/AltDirectorySeparator, but those vary per-platform and we want this
-        // logic to work cross-platform (for tests)
-        else if c = '\\' then
-            uri.Append('/') |> ignore
-        else
-            uri.Append('%') |> ignore
-            uri.Append((int c).ToString("X2")) |> ignore
-
-    if uri.Length >= 2 && uri[0] = '/' && uri[1] = '/' then // UNC path
-        "file:" + uri.ToString()
-    else
-        "file:///" + uri.ToString().TrimStart('/')
-
-module PathUri =
-    let ofString (str: string) : PathUri =
-        let unescaped = Uri.UnescapeDataString(str)
-        let uri = Uri(unescaped)
-        let localPath = uri.LocalPath
-
-        let isWin =
-            localPath.Length >= 2
-            && Char.IsLetter(localPath[0])
-            && localPath[1] = ':'
-
-        let localPath =
-            if isWin then
-                Char.ToLower(localPath[0]).ToString() + localPath[1..]
-            else
-                localPath
-
-        let escapedUri =
-            if str.StartsWith("file://") then
-                str
-            else
-                localPathToUriString localPath
-
-        { uri = escapedUri; localPath = localPath }
 
 type Position with
 

--- a/Marksman/Misc.fs
+++ b/Marksman/Misc.fs
@@ -2,6 +2,7 @@ module Marksman.Misc
 
 open System
 open System.IO
+open System.Runtime.InteropServices
 open System.Text
 open System.Text.RegularExpressions
 
@@ -16,6 +17,8 @@ let concatLines (lines: array<string>) : string = String.concat Environment.NewL
 let mkWatchGlob (configuredExts: seq<string>) : string =
     let ext_pattern = "{" + (String.concat "," (configuredExts)) + "}"
     $"**/*.{ext_pattern}"
+
+let isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
 
 let isMarkdownFile (configuredExts: seq<string>) (path: string) : bool =
     let isEmacsBackup =

--- a/Marksman/Names.fs
+++ b/Marksman/Names.fs
@@ -1,0 +1,72 @@
+module Marksman.Names
+
+open System
+open Marksman.Misc
+open Marksman.Paths
+
+type UrlEncoded = UrlEncoded of string
+
+module UrlEncoded =
+    let mkUnchecked = UrlEncoded
+    let encode (str: string) = UrlEncoded(str.UrlEncode())
+
+    let decode (UrlEncoded str) = str.UrlDecode()
+
+type WikiEncoded = WikiEncoded of string
+
+module WikiEncoded =
+    let mkUnchecked = WikiEncoded
+    let encode (str: string) = WikiEncoded(str.EncodeForWiki())
+    let raw (WikiEncoded raw) = raw
+
+type FolderId = UriWith<RootPath>
+
+module FolderId =
+    let ofUri uri = UriWith.mkRoot uri
+
+type DocId = UriWith<RootedRelPath>
+
+type InternName = { src: DocId; name: string }
+
+module InternName =
+    let mkUnchecked src name = { src = src; name = name }
+
+    let mkChecked exts src name =
+        if Uri.IsWellFormedUriString(name, UriKind.Absolute) then
+            None
+        else if isPotentiallyMarkdownFile exts name then
+            Some({ src = src; name = name })
+        else
+            None
+
+    let name { name = name } = name
+
+    let slug { name = name } = Slug.ofString name
+
+    let src { src = src } = src
+
+    let tryAsPath ({ src = src; name = name }: InternName) =
+        if Uri.IsWellFormedUriString(name, UriKind.Absolute) then
+            None
+        else if name.StartsWith('/') then
+            let relPath =
+                LocalPath.ofSystem (
+                    UrlEncoded.mkUnchecked (name.TrimStart('/')) |> UrlEncoded.decode
+                )
+
+            let rootPath = src.data.root
+            let namePath = RootedRelPath.mk rootPath relPath
+            Some(namePath)
+        else
+            try
+                let rawNamePath =
+                    LocalPath.ofSystem (UrlEncoded.mkUnchecked name |> UrlEncoded.decode)
+
+                RootedRelPath.combine (RootedRelPath.directory src.data) rawNamePath
+            with
+            | :? UriFormatException
+            | :? InvalidOperationException -> None
+
+    let asPath name =
+        tryAsPath name
+        |> Option.defaultWith (fun () -> failwith $"Can't convert InternName {name} to a path")

--- a/Marksman/Names.fsi
+++ b/Marksman/Names.fsi
@@ -26,11 +26,19 @@ type DocId = UriWith<RootedRelPath>
 
 type InternName = { src: DocId; name: string }
 
+type InternPath =
+    | ExactAbs of RootedRelPath
+    | ExactRel of src: DocId * path: RootedRelPath
+    | Approx of RelPath
+
+module InternPath =
+    val toRel: InternPath -> RelPath
+
 module InternName =
     val mkUnchecked: DocId -> string -> InternName
     val mkChecked: exts: seq<string> -> DocId -> name: string -> option<InternName>
     val name: InternName -> string
     val slug: InternName -> Slug
     val src: InternName -> DocId
-    val tryAsPath: InternName -> option<RootedRelPath>
-    val asPath: InternName -> RootedRelPath
+    val tryAsPath: InternName -> option<InternPath>
+    val asPath: InternName -> InternPath

--- a/Marksman/Names.fsi
+++ b/Marksman/Names.fsi
@@ -1,0 +1,36 @@
+module Marksman.Names
+
+open Ionide.LanguageServerProtocol.Types
+open Marksman.Misc
+open Marksman.Paths
+
+type UrlEncoded = UrlEncoded of string
+
+module UrlEncoded =
+    val mkUnchecked: string -> UrlEncoded
+    val encode: string -> UrlEncoded
+
+type WikiEncoded = WikiEncoded of string
+
+module WikiEncoded =
+    val mkUnchecked: string -> WikiEncoded
+    val encode: string -> WikiEncoded
+    val raw: WikiEncoded -> string
+
+type FolderId = UriWith<RootPath>
+
+module FolderId =
+    val ofUri: DocumentUri -> FolderId
+
+type DocId = UriWith<RootedRelPath>
+
+type InternName = { src: DocId; name: string }
+
+module InternName =
+    val mkUnchecked: DocId -> string -> InternName
+    val mkChecked: exts: seq<string> -> DocId -> name: string -> option<InternName>
+    val name: InternName -> string
+    val slug: InternName -> Slug
+    val src: InternName -> DocId
+    val tryAsPath: InternName -> option<RootedRelPath>
+    val asPath: InternName -> RootedRelPath

--- a/Marksman/Parser.fs
+++ b/Marksman/Parser.fs
@@ -6,6 +6,7 @@ open Markdig.Syntax
 
 open Marksman.Cst
 open Marksman.Misc
+open Marksman.Names
 open Marksman.Text
 
 module Markdown =
@@ -236,13 +237,18 @@ module Markdown =
                 let doc =
                     match link.Doc, link.DocSpan with
                     | Some doc, Some docSpan ->
-                        Node.mkText doc (sourceSpanToRange text docSpan) |> Some
+                        Node.mk doc (sourceSpanToRange text docSpan) (WikiEncoded.mkUnchecked doc)
+                        |> Some
                     | _ -> None
 
                 let heading =
                     match link.Heading, link.HeadingSpan with
                     | Some heading, Some headingSpan ->
-                        Node.mkText heading (sourceSpanToRange text headingSpan) |> Some
+                        Node.mk
+                            heading
+                            (sourceSpanToRange text headingSpan)
+                            (WikiEncoded.mkUnchecked heading)
+                        |> Some
                     | _ -> None
 
                 let wikiLink: WikiLink = { doc = doc; heading = heading }
@@ -278,7 +284,12 @@ module Markdown =
                             if urlSpan.IsEmpty then
                                 None
                             else
-                                Some(Node.mkText url (sourceSpanToRange text urlSpan))
+                                Some(
+                                    Node.mk
+                                        url
+                                        (sourceSpanToRange text urlSpan)
+                                        (UrlEncoded.mkUnchecked url)
+                                )
 
                         let title =
                             if titleSpan.IsEmpty then
@@ -318,7 +329,9 @@ module Markdown =
 
                 let url = linkDef.Url
                 let urlSpan = linkDef.UrlSpan
-                let url = Node.mkText url (sourceSpanToRange text urlSpan)
+
+                let url =
+                    Node.mk url (sourceSpanToRange text urlSpan) (UrlEncoded.mkUnchecked url)
 
                 let title =
                     if linkDef.TitleSpan.IsEmpty then

--- a/Marksman/Parser.fs
+++ b/Marksman/Parser.fs
@@ -4,9 +4,9 @@ open System
 open Ionide.LanguageServerProtocol.Types
 open Markdig.Syntax
 
-open Marksman.Text
 open Marksman.Cst
 open Marksman.Misc
+open Marksman.Text
 
 module Markdown =
     open Markdig

--- a/Marksman/Paths.fs
+++ b/Marksman/Paths.fs
@@ -1,35 +1,14 @@
 module Marksman.Paths
 
 open System
+open System.IO
+open System.Runtime.InteropServices
 open System.Text
 
-[<CustomEquality; CustomComparison>]
-type PathUri =
-    private
-        { uri: string
-          localPath: string }
-
-    member this.DocumentUri: string = this.uri
-
-    member this.LocalPath: string = this.localPath
-
-    override this.Equals(obj) =
-        match obj with
-        | :? PathUri as other -> this.LocalPath.Equals(other.LocalPath)
-        | _ -> false
-
-
-    override this.GetHashCode() = this.LocalPath.GetHashCode()
-
-    interface IComparable with
-        member this.CompareTo(obj) =
-            match obj with
-            | :? PathUri as other -> this.LocalPath.CompareTo(other.LocalPath)
-            | _ -> failwith "Incompatible Type"
-
+open Ionide.LanguageServerProtocol.Types
 
 // https://github.dev/fsharp/FsAutoComplete/blob/d90597c2e073b7e88390f2b1933b031ff8a9a009/src/FsAutoComplete.Core/Utils.fs#L635
-let localPathToUriString (filePath: string) : string =
+let systemPathToUriString (filePath: string) : string =
     let uri = StringBuilder(filePath.Length)
 
     for c in filePath do
@@ -60,34 +39,293 @@ let localPathToUriString (filePath: string) : string =
     else
         "file:///" + uri.ToString().TrimStart('/')
 
-module PathUri =
-    let ofString (str: string) : PathUri =
-        let unescaped = Uri.UnescapeDataString(str)
-        let uri = Uri(unescaped)
-        let localPath = uri.LocalPath
+let uriToSystemPath (uri: DocumentUri) : string =
+    let unescaped = Uri.UnescapeDataString(uri)
+    let uri = Uri(unescaped)
+    let localPath = uri.LocalPath
 
-        let isWin =
-            localPath.Length >= 2
-            && Char.IsLetter(localPath[0])
-            && localPath[1] = ':'
+    let isWin =
+        localPath.Length >= 2
+        && Char.IsLetter(localPath[0])
+        && localPath[1] = ':'
 
-        let localPath =
-            if isWin then
-                Char.ToLower(localPath[0]).ToString() + localPath[1..]
-            else
-                localPath
+    let localPath =
+        if isWin then
+            Char.ToLower(localPath[0]).ToString() + localPath[1..]
+        else
+            localPath
 
-        let escapedUri =
-            if str.StartsWith("file://") then
-                str
-            else
-                localPathToUriString localPath
+    localPath
 
-        { uri = escapedUri; localPath = localPath }
+type Platform =
+    | Unix
+    | Win
 
-type RootPath = RootPath of PathUri
+type DirSeparator =
+    | Forward
+    | Backward
+
+module DirSeparator =
+    let sepChar =
+        function
+        | Forward -> '/'
+        | Backward -> '\\'
+
+    let sepString =
+        function
+        | Forward -> "/"
+        | Backward -> "\\"
+
+    let platformSep =
+        if RuntimeInformation.IsOSPlatform(OSPlatform.Windows) then
+            Backward
+        else
+            Forward
+
+type AbsPath =
+    | AbsPath of string
+
+    member this.GetDirectoryName() : AbsPath =
+        let (AbsPath raw) = this
+        AbsPath(Path.GetDirectoryName(raw))
+
+and RelPath =
+    | RelPath of string
+
+    member this.GetDirectoryName() : AbsPath =
+        let (RelPath raw) = this
+        AbsPath(Path.GetDirectoryName(raw))
+
+and LocalPath =
+    | Abs of AbsPath
+    | Rel of RelPath
+
+    member this.Raw: string =
+        match this with
+        | Abs (AbsPath str)
+        | Rel (RelPath str) -> str
+
+module AbsPath =
+    let isRawWinAbsPath str = String.length str >= 2 && Char.IsLetter(str[0]) && str[1] = ':'
+
+    let isRawUnixAbsPath str = String.length str > 0 && str[0] = '/'
+
+    let isRawAbsPath str = isRawUnixAbsPath str || isRawWinAbsPath str
+
+    let isRootComponent str =
+        str = "/"
+        || (String.length str = 2 && Char.IsLetter(str[0]) && str[1] = ':')
+
+    let tryOfSystem str =
+        if isRawWinAbsPath str then
+            // TODO: normalize the drive letter? Leave as-is for now until the requirements are
+            // clearer
+            AbsPath str |> Some
+        else if isRawUnixAbsPath str then
+            AbsPath str |> Some
+        else
+            None
+
+    let ofSystem str =
+        tryOfSystem str
+        |> Option.defaultWith (fun () -> failwith $"Bad absolute path: {str}")
+
+    let ofUri (rawUri: DocumentUri) : AbsPath = ofSystem (uriToSystemPath rawUri)
+
+    let toSystem (AbsPath raw) = raw
+
+    let toUri path = systemPathToUriString (toSystem path)
+
+    let appendFile (AbsPath raw) (filename: string) = AbsPath(Path.Combine(raw, filename))
+
+    let append (AbsPath abs) (RelPath rel) = AbsPath(Path.Combine(abs, rel))
+
+    let resolve (AbsPath raw) = Path.GetFullPath(raw) |> AbsPath
+
+    let contains (AbsPath outer) (AbsPath inner) = inner.StartsWith(outer)
+
+    let filename (AbsPath sys) = Path.GetFileName(sys)
+    let filenameStem (AbsPath sys) = Path.GetFileNameWithoutExtension(sys)
+
+module RelPath =
+    let ofStringUnchecked str = RelPath str
+    let toSystem (RelPath p) = p
+    let filename (RelPath p) = Path.GetFileName(p)
+    let filenameStem (RelPath p) = Path.GetFileNameWithoutExtension(p)
+    let directory (RelPath p) = Path.GetDirectoryName(p) |> RelPath
+
+
+module LocalPath =
+    let tryOfSystem str =
+        if String.IsNullOrEmpty str then
+            None
+        else
+            match AbsPath.tryOfSystem str with
+            | Some path -> Some(Abs path)
+            | None -> Some(Rel(RelPath.ofStringUnchecked str))
+
+    let ofSystem str =
+        tryOfSystem str
+        |> Option.defaultWith (fun () -> failwith $"String {str} couldn't be converted to a path")
+
+    let toSystem (path: LocalPath) = path.Raw
+
+    let isAbsolute =
+        function
+        | Abs _ -> true
+        | Rel _ -> false
+
+    let isRelative =
+        function
+        | Abs _ -> false
+        | Rel _ -> true
+
+    let components path =
+        let raw = toSystem path
+        let components = raw.Split([| '\\'; '/' |])
+        Array.filter (String.IsNullOrEmpty >> not) components
+
+    // TODO: this is pretty ridiculous. Think of a better way.
+    let dominatingDirectorySeparator path =
+        let raw = toSystem path
+
+        let numForward, numBackward =
+            raw.ToCharArray()
+            |> Array.fold
+                (fun (numForward, numBackward) c ->
+                    if c = '/' then (numForward + 1, numBackward)
+                    else if c = '\\' then (numForward, numBackward + 1)
+                    else (numForward, numBackward))
+                (0, 0)
+
+        if numForward >= numBackward then '/' else '\\'
+
+    let startsWithString (str: string) path = (toSystem path).StartsWith(str)
+
+    let normalize path =
+        let comps = components path |> Array.toList
+        let isAbs = isAbsolute path
+
+        let normalizer (acc: list<string>) (comp: string) =
+            match acc, comp with
+            | [], ".." when isAbs -> []
+            | [], "." -> []
+            | [], comp -> [ comp ]
+            | acc, "." -> acc
+            | [ accHd ], ".." when AbsPath.isRootComponent accHd -> acc
+            | ".." :: _, ".." -> ".." :: acc
+            | _ :: accTl, ".." -> accTl
+            | _, _ -> comp :: acc
+
+        let comps = List.fold normalizer [] comps |> List.rev
+        let sep = (dominatingDirectorySeparator path).ToString()
+        let newPath = String.Join(sep, comps)
+        let newPath = if startsWithString "/" path then "/" + newPath else newPath
+
+        tryOfSystem newPath
+        |> Option.defaultWith (fun () -> failwith "Path normalization failed")
+
+    let ofUri (rawUri: DocumentUri) : LocalPath = ofSystem (uriToSystemPath rawUri)
+
+    let toUri path = systemPathToUriString (toSystem path)
+
+    let appendFile path filename =
+        let sysPath = toSystem path
+        let extended = Path.Combine(sysPath, filename)
+
+        match path with
+        | Abs _ -> Abs(AbsPath extended)
+        | Rel _ -> Rel(RelPath extended)
+
+    let combine p1 p2 =
+        match p1, p2 with
+        | _, Abs _ -> p2
+        | _, Rel relPath ->
+            let sys1 = toSystem p1
+            let sys2 = toSystem p2
+            let sysComb = Path.Combine(sys1, sys2)
+
+            match p1 with
+            | Rel _ -> Rel(RelPath sysComb)
+            | Abs _ -> Abs(AbsPath sysComb)
+
+    let filename path = Path.GetFileName(toSystem path)
+
+    let filenameStem path = Path.GetFileNameWithoutExtension(toSystem path)
+
+    let directory path =
+        let dir = Path.GetDirectoryName(toSystem path)
+        ofSystem dir
+
+type RootPath =
+    | RootPath of AbsPath
+
+    member this.Path =
+        let (RootPath path) = this
+        path
 
 module RootPath =
     let ofPath path = RootPath path
-    let ofString s = ofPath (PathUri.ofString s)
-    let path (RootPath p) = p
+    let toLocal (RootPath p) = Abs p
+    let toSystem (RootPath p) = AbsPath.toSystem p
+    let toUri (RootPath p) = AbsPath.toUri p
+    let resolve (RootPath p) = AbsPath.resolve p
+    let append (RootPath p) relPath = AbsPath.append p relPath
+    let appendFile (RootPath p) filename = AbsPath.appendFile p filename
+
+    let contains (RootPath enclosing) (path: LocalPath) =
+        match path with
+        | Rel _ -> true
+        | Abs enclosed ->
+            let (AbsPath enclosing) = AbsPath.resolve enclosing
+            let (AbsPath enclosed) = AbsPath.resolve enclosed
+            enclosed.StartsWith(enclosing)
+
+    let filename (RootPath p) = AbsPath.filename p
+    let filenameStem (RootPath p) = AbsPath.filenameStem p
+
+type RootedRelPath = { root: RootPath; path: RelPath }
+
+module RootedRelPath =
+    let mk root path =
+        match path with
+        | Rel path -> { root = root; path = path }
+        | Abs path ->
+            let (AbsPath sysRoot) = RootPath.resolve root
+            let (AbsPath sysOther) = AbsPath.resolve path
+            let relPath = Path.GetRelativePath(sysRoot, sysOther)
+            { root = root; path = RelPath relPath }
+
+    let toAbs path = RootPath.append path.root path.path
+    let toLocal path = Abs(toAbs path)
+    let toSystem path = toAbs path |> AbsPath.toSystem
+    let toUri path = LocalPath.toUri (toLocal path)
+    let filename path = RelPath.filename path.path
+    let filenameStem path = RelPath.filenameStem path.path
+
+    let directory path =
+        let dir = path.path |> RelPath.directory
+        { root = path.root; path = dir }
+
+    let combine (root: RootedRelPath) (path: LocalPath) : option<RootedRelPath> =
+        match LocalPath.combine (toLocal root) path with
+        | Rel _ -> None
+        | Abs out ->
+            if RootPath.contains root.root (Abs out) then
+                mk root.root (Abs out) |> Some
+            else
+                None
+
+type UriWith<'T> = { uri: DocumentUri; data: 'T }
+
+module UriWith =
+    let mkAbs uri = { uri = uri; data = AbsPath.ofUri uri }
+    let mkRoot uri = { uri = uri; data = AbsPath.ofUri uri |> RootPath }
+
+    let mkRooted root path =
+        let relPath = RootedRelPath.mk root.data path
+        { uri = RootedRelPath.toUri relPath; data = relPath }
+
+    let rootedRelToAbs uri =
+        let localPath = RootedRelPath.toAbs uri.data
+        { uri = uri.uri; data = localPath }

--- a/Marksman/Paths.fs
+++ b/Marksman/Paths.fs
@@ -175,6 +175,11 @@ module LocalPath =
         | Abs _ -> true
         | Rel _ -> false
 
+    let asAbsolute =
+        function
+        | Abs path -> path
+        | Rel path -> failwith $"Path {path} is not absolute"
+
     let isRelative =
         function
         | Abs _ -> false
@@ -184,6 +189,17 @@ module LocalPath =
         let raw = toSystem path
         let components = raw.Split([| '\\'; '/' |])
         Array.filter (String.IsNullOrEmpty >> not) components
+
+    let ofComponents comps =
+        assert (Array.length comps > 0)
+
+        let sysPath =
+            if comps[0] = "/" then
+                "/" + String.Join(Path.DirectorySeparatorChar, comps[1..])
+            else
+                String.Join(Path.DirectorySeparatorChar, comps)
+
+        ofSystem sysPath
 
     // TODO: this is pretty ridiculous. Think of a better way.
     let dominatingDirectorySeparator path =

--- a/Marksman/Paths.fs
+++ b/Marksman/Paths.fs
@@ -1,0 +1,93 @@
+module Marksman.Paths
+
+open System
+open System.Text
+
+[<CustomEquality; CustomComparison>]
+type PathUri =
+    private
+        { uri: string
+          localPath: string }
+
+    member this.DocumentUri: string = this.uri
+
+    member this.LocalPath: string = this.localPath
+
+    override this.Equals(obj) =
+        match obj with
+        | :? PathUri as other -> this.LocalPath.Equals(other.LocalPath)
+        | _ -> false
+
+
+    override this.GetHashCode() = this.LocalPath.GetHashCode()
+
+    interface IComparable with
+        member this.CompareTo(obj) =
+            match obj with
+            | :? PathUri as other -> this.LocalPath.CompareTo(other.LocalPath)
+            | _ -> failwith "Incompatible Type"
+
+
+// https://github.dev/fsharp/FsAutoComplete/blob/d90597c2e073b7e88390f2b1933b031ff8a9a009/src/FsAutoComplete.Core/Utils.fs#L635
+let localPathToUriString (filePath: string) : string =
+    let uri = StringBuilder(filePath.Length)
+
+    for c in filePath do
+        if
+            (c >= 'a' && c <= 'z')
+            || (c >= 'A' && c <= 'Z')
+            || (c >= '0' && c <= '9')
+            || c = '+'
+            || c = '/'
+            || c = '.'
+            || c = '-'
+            || c = '_'
+            || c = '~'
+            || c > '\xFF'
+        then
+            uri.Append(c) |> ignore
+        // handle windows path separator chars.
+        // we _would_ use Path.DirectorySeparator/AltDirectorySeparator, but those vary per-platform and we want this
+        // logic to work cross-platform (for tests)
+        else if c = '\\' then
+            uri.Append('/') |> ignore
+        else
+            uri.Append('%') |> ignore
+            uri.Append((int c).ToString("X2")) |> ignore
+
+    if uri.Length >= 2 && uri[0] = '/' && uri[1] = '/' then // UNC path
+        "file:" + uri.ToString()
+    else
+        "file:///" + uri.ToString().TrimStart('/')
+
+module PathUri =
+    let ofString (str: string) : PathUri =
+        let unescaped = Uri.UnescapeDataString(str)
+        let uri = Uri(unescaped)
+        let localPath = uri.LocalPath
+
+        let isWin =
+            localPath.Length >= 2
+            && Char.IsLetter(localPath[0])
+            && localPath[1] = ':'
+
+        let localPath =
+            if isWin then
+                Char.ToLower(localPath[0]).ToString() + localPath[1..]
+            else
+                localPath
+
+        let escapedUri =
+            if str.StartsWith("file://") then
+                str
+            else
+                localPathToUriString localPath
+
+        { uri = escapedUri; localPath = localPath }
+
+type RootPath = RootPath of PathUri
+
+module RootPath =
+    let ofPath path = RootPath path
+    let ofString s = ofPath (PathUri.ofString s)
+    let path (RootPath p) = p

--- a/Marksman/Paths.fs
+++ b/Marksman/Paths.fs
@@ -107,6 +107,8 @@ and LocalPath =
         | Abs (AbsPath str)
         | Rel (RelPath str) -> str
 
+type PathStem<'T> = PathStem of 'T
+
 module AbsPath =
     let isRawWinAbsPath str = String.length str >= 2 && Char.IsLetter(str[0]) && str[1] = ':'
 
@@ -157,9 +159,11 @@ module RelPath =
 
     let filepathStem (RelPath p) =
         let ext = Path.GetExtension(p)
-        RelPath(p.TrimSuffix(ext))
+        PathStem(RelPath(p.TrimSuffix(ext)))
 
     let directory (RelPath p) = Path.GetDirectoryName(p) |> RelPath
+
+    let hasExtension (RelPath p) = Path.GetExtension(p).IsEmpty() |> not
 
 
 module LocalPath =

--- a/Marksman/Paths.fs
+++ b/Marksman/Paths.fs
@@ -5,6 +5,8 @@ open System.IO
 open System.Runtime.InteropServices
 open System.Text
 
+open Marksman.Misc
+
 open Ionide.LanguageServerProtocol.Types
 
 // https://github.dev/fsharp/FsAutoComplete/blob/d90597c2e073b7e88390f2b1933b031ff8a9a009/src/FsAutoComplete.Core/Utils.fs#L635
@@ -152,6 +154,11 @@ module RelPath =
     let toSystem (RelPath p) = p
     let filename (RelPath p) = Path.GetFileName(p)
     let filenameStem (RelPath p) = Path.GetFileNameWithoutExtension(p)
+
+    let filepathStem (RelPath p) =
+        let ext = Path.GetExtension(p)
+        RelPath(p.TrimSuffix(ext))
+
     let directory (RelPath p) = Path.GetDirectoryName(p) |> RelPath
 
 
@@ -189,6 +196,8 @@ module LocalPath =
         let raw = toSystem path
         let components = raw.Split([| '\\'; '/' |])
         Array.filter (String.IsNullOrEmpty >> not) components
+
+    let hasDotComponents path = components path |> Array.exists (fun x -> x = "." || x = "..")
 
     let ofComponents comps =
         assert (Array.length comps > 0)

--- a/Marksman/Paths.fsi
+++ b/Marksman/Paths.fsi
@@ -31,8 +31,10 @@ module LocalPath =
     val tryOfSystem: string -> Option<LocalPath>
     val ofSystem: string -> LocalPath
     val ofUri: DocumentUri -> LocalPath
+    val ofComponents: array<string> -> LocalPath
     val toSystem: LocalPath -> string
     val isAbsolute: LocalPath -> bool
+    val asAbsolute: LocalPath -> AbsPath
     val isRelative: LocalPath -> bool
     val components: LocalPath -> array<string>
     val normalize: LocalPath -> LocalPath

--- a/Marksman/Paths.fsi
+++ b/Marksman/Paths.fsi
@@ -11,6 +11,8 @@ type LocalPath =
     | Abs of AbsPath
     | Rel of RelPath
 
+type PathStem<'T> = PathStem of 'T
+
 module AbsPath =
     val ofUri: DocumentUri -> AbsPath
     val ofSystem: string -> AbsPath
@@ -26,7 +28,8 @@ module RelPath =
     val toSystem: RelPath -> string
     val filename: RelPath -> string
     val filenameStem: RelPath -> string
-    val filepathStem: RelPath -> RelPath
+    val filepathStem: RelPath -> PathStem<RelPath>
+    val hasExtension: RelPath -> bool
 
 module LocalPath =
     val tryOfSystem: string -> Option<LocalPath>

--- a/Marksman/Paths.fsi
+++ b/Marksman/Paths.fsi
@@ -1,19 +1,79 @@
 module Marksman.Paths
 
-[<Sealed>]
-type PathUri =
-    interface System.IComparable
-    member LocalPath: string
-    member DocumentUri: string
+open Ionide.LanguageServerProtocol.Types
 
-module PathUri =
-    val ofString: string -> PathUri
+val systemPathToUriString: string -> DocumentUri
 
-[<Sealed>]
+type AbsPath = AbsPath of string
+type RelPath = RelPath of string
+
+type LocalPath =
+    | Abs of AbsPath
+    | Rel of RelPath
+
+module AbsPath =
+    val ofUri: DocumentUri -> AbsPath
+    val ofSystem: string -> AbsPath
+    val toSystem: AbsPath -> string
+    val toUri: AbsPath -> DocumentUri
+    val append: AbsPath -> RelPath -> AbsPath
+    val appendFile: AbsPath -> filename: string -> AbsPath
+    val contains: outer: AbsPath -> inner: AbsPath -> bool
+    val filename: AbsPath -> string
+    val filenameStem: AbsPath -> string
+
+module RelPath =
+    val toSystem: RelPath -> string
+    val filename: RelPath -> string
+    val filenameStem: RelPath -> string
+
+module LocalPath =
+    val tryOfSystem: string -> Option<LocalPath>
+    val ofSystem: string -> LocalPath
+    val ofUri: DocumentUri -> LocalPath
+    val toSystem: LocalPath -> string
+    val isAbsolute: LocalPath -> bool
+    val isRelative: LocalPath -> bool
+    val components: LocalPath -> array<string>
+    val normalize: LocalPath -> LocalPath
+    val appendFile: LocalPath -> filename: string -> LocalPath
+    val combine: LocalPath -> LocalPath -> LocalPath
+    val filename: LocalPath -> string
+    val filenameStem: LocalPath -> string
+    val directory: LocalPath -> LocalPath
+
 type RootPath =
-    interface System.IComparable
+    | RootPath of AbsPath
+
+    member Path: AbsPath
 
 module RootPath =
-    val ofPath: PathUri -> RootPath
-    val ofString: string -> RootPath
-    val path: RootPath -> PathUri
+    val ofPath: AbsPath -> RootPath
+    val toLocal: RootPath -> LocalPath
+    val toSystem: RootPath -> string
+    val toUri: RootPath -> DocumentUri
+    val append: RootPath -> RelPath -> AbsPath
+    val appendFile: RootPath -> filename: string -> AbsPath
+    val contains: RootPath -> LocalPath -> bool
+    val filename: RootPath -> string
+    val filenameStem: RootPath -> string
+
+type RootedRelPath = { root: RootPath; path: RelPath }
+
+module RootedRelPath =
+    val mk: RootPath -> LocalPath -> RootedRelPath
+    val toAbs: RootedRelPath -> AbsPath
+    val toSystem: RootedRelPath -> string
+    val toUri: RootedRelPath -> DocumentUri
+    val combine: RootedRelPath -> LocalPath -> option<RootedRelPath>
+    val filename: RootedRelPath -> string
+    val filenameStem: RootedRelPath -> string
+    val directory: RootedRelPath -> RootedRelPath
+
+type UriWith<'T> = { uri: DocumentUri; data: 'T }
+
+module UriWith =
+    val mkAbs: DocumentUri -> UriWith<AbsPath>
+    val mkRoot: DocumentUri -> UriWith<RootPath>
+    val mkRooted: UriWith<RootPath> -> LocalPath -> UriWith<RootedRelPath>
+    val rootedRelToAbs: UriWith<RootedRelPath> -> UriWith<AbsPath>

--- a/Marksman/Paths.fsi
+++ b/Marksman/Paths.fsi
@@ -26,6 +26,7 @@ module RelPath =
     val toSystem: RelPath -> string
     val filename: RelPath -> string
     val filenameStem: RelPath -> string
+    val filepathStem: RelPath -> RelPath
 
 module LocalPath =
     val tryOfSystem: string -> Option<LocalPath>
@@ -37,6 +38,7 @@ module LocalPath =
     val asAbsolute: LocalPath -> AbsPath
     val isRelative: LocalPath -> bool
     val components: LocalPath -> array<string>
+    val hasDotComponents: LocalPath -> bool
     val normalize: LocalPath -> LocalPath
     val appendFile: LocalPath -> filename: string -> LocalPath
     val combine: LocalPath -> LocalPath -> LocalPath

--- a/Marksman/Paths.fsi
+++ b/Marksman/Paths.fsi
@@ -1,0 +1,19 @@
+module Marksman.Paths
+
+[<Sealed>]
+type PathUri =
+    interface System.IComparable
+    member LocalPath: string
+    member DocumentUri: string
+
+module PathUri =
+    val ofString: string -> PathUri
+
+[<Sealed>]
+type RootPath =
+    interface System.IComparable
+
+module RootPath =
+    val ofPath: PathUri -> RootPath
+    val ofString: string -> RootPath
+    val path: RootPath -> PathUri

--- a/Marksman/Refactor.fs
+++ b/Marksman/Refactor.fs
@@ -2,10 +2,10 @@ module Marksman.Refactor
 
 open Ionide.LanguageServerProtocol.Types
 
-open Marksman.Workspace
 open Marksman.Cst
 open Marksman.Misc
 open Marksman.Refs
+open Marksman.Workspace
 
 type RenameResult =
     | Edit of WorkspaceEdit

--- a/Marksman/Refs.fs
+++ b/Marksman/Refs.fs
@@ -142,7 +142,7 @@ module FileLink =
 
                         if
                             nameFileStem.AbsPathUrlEncode() = docFileStem.AbsPathUrlEncode()
-                            && (linkRootPath.path |> RelPath.toSystem)
+                            && (linkRootPath |> InternPath.toRel |> RelPath.toSystem)
                                 .AbsPathUrlEncode()
                                 .IsSubStringOf(
                                     (Doc.pathFromRoot doc |> RelPath.toSystem).AbsPathUrlEncode()
@@ -177,7 +177,7 @@ module FileLink =
         let byPath () =
             match InternName.tryAsPath name with
             | Some linkRootPath ->
-                (linkRootPath.path |> RelPath.toSystem)
+                (linkRootPath |> InternPath.toRel |> RelPath.toSystem)
                     .AbsPathUrlEncode()
                     .IsSubStringOf((Doc.pathFromRoot doc |> RelPath.toSystem).AbsPathUrlEncode())
             | None -> false

--- a/Marksman/Refs.fs
+++ b/Marksman/Refs.fs
@@ -11,6 +11,7 @@ open Ionide.LanguageServerProtocol.Types
 open Marksman.Cst
 open Marksman.Index
 open Marksman.Misc
+open Marksman.Paths
 open Marksman.Workspace
 
 type InternName = InternName of string

--- a/Marksman/Server.fs
+++ b/Marksman/Server.fs
@@ -16,10 +16,10 @@ open Marksman.Cst
 open Marksman.Diag
 open Marksman.Index
 open Marksman.Misc
+open Marksman.Paths
 open Marksman.Refs
 open Marksman.State
 open Marksman.Workspace
-open Newtonsoft.Json.Linq
 
 module ServerUtil =
     let logger = LogProvider.getLoggerByName "ServerUtil"

--- a/Marksman/State.fs
+++ b/Marksman/State.fs
@@ -7,7 +7,7 @@ open FSharpPlus.GenericBuilders
 
 open Marksman.Diag
 open Marksman.Workspace
-open Marksman.Misc
+open Marksman.Paths
 open Marksman.Config
 open Newtonsoft.Json.Linq
 

--- a/Marksman/Symbols.fs
+++ b/Marksman/Symbols.fs
@@ -3,6 +3,7 @@ module Marksman.Symbols
 open Ionide.LanguageServerProtocol.Types
 
 open Marksman.Misc
+open Marksman.Paths
 open Marksman.Cst
 open Marksman.Workspace
 open Marksman.Index

--- a/Marksman/Symbols.fs
+++ b/Marksman/Symbols.fs
@@ -4,16 +4,17 @@ open Ionide.LanguageServerProtocol.Types
 
 open Marksman.Misc
 open Marksman.Paths
+open Marksman.Names
 open Marksman.Cst
 open Marksman.Workspace
 open Marksman.Index
 
-let headingToSymbolInfo (docUri: PathUri) (h: Node<Heading>) : SymbolInformation =
+let headingToSymbolInfo (docUri: DocId) (h: Node<Heading>) : SymbolInformation =
     let name = Heading.name h.data
     let name = $"H{h.data.level}: {name}"
     let kind = SymbolKind.String
 
-    let location = { Uri = docUri.DocumentUri; Range = h.range }
+    let location = { Uri = docUri.uri; Range = h.range }
 
     let sym =
         { Name = name
@@ -76,7 +77,7 @@ let docSymbols
         let allHeadings = Doc.index >> Index.headings <| doc
 
         allHeadings
-        |> Seq.map (headingToSymbolInfo (Doc.path doc))
+        |> Seq.map (headingToSymbolInfo (Doc.id doc))
         |> Array.ofSeq
         |> First
 
@@ -91,7 +92,7 @@ let workspaceSymbols (query: string) (ws: Workspace) : array<SymbolInformation> 
                     |> Seq.filter (fun { data = h } -> query.IsSubSequenceOf(Heading.name h))
 
                 let matchingSymbols =
-                    matchingHeadings |> Seq.map (headingToSymbolInfo (Doc.path doc))
+                    matchingHeadings |> Seq.map (headingToSymbolInfo (Doc.id doc))
 
                 yield! matchingSymbols
     }

--- a/Marksman/Toc.fs
+++ b/Marksman/Toc.fs
@@ -3,9 +3,9 @@ module Marksman.Toc
 open Ionide.LanguageServerProtocol.Types
 open Ionide.LanguageServerProtocol.Logging
 
-open Marksman.Misc
-open Marksman.Index
 open Marksman.Cst
+open Marksman.Index
+open Marksman.Misc
 open Marksman.Text
 open Marksman.Workspace
 

--- a/Marksman/Workspace.fs
+++ b/Marksman/Workspace.fs
@@ -194,6 +194,15 @@ module Folder =
             let rooted = (RootedRelPath.mk root.data (Abs uri))
             Map.tryFind rooted.path docs
 
+    let tryFindDocByRelPath (path: RelPath) : Folder -> option<Doc> =
+        function
+        | SingleFile { doc = doc } ->
+            Some doc
+            |> Option.filter (fun x ->
+                let sysPath = ((Doc.path x) |> AbsPath.toSystem)
+                sysPath.EndsWith(path |> RelPath.toSystem))
+        | MultiFile { docs = docs } -> Map.tryFind path docs
+
     let private readIgnoreFiles (root: LocalPath) : array<string> =
         let lines = ResizeArray()
 

--- a/Marksman/Workspace.fs
+++ b/Marksman/Workspace.fs
@@ -12,6 +12,7 @@ open Marksman.Config
 open Marksman.Parser
 open Marksman.Text
 open Marksman.Misc
+open Marksman.Paths
 open Marksman.Cst
 open Marksman.Index
 
@@ -23,12 +24,6 @@ module FolderId =
     let ofPath path = FolderId path
     let path (FolderId p) = p
 
-type RootPath = RootPath of PathUri
-
-module RootPath =
-    let ofPath path = RootPath path
-    let ofString s = ofPath (PathUri.ofString s)
-    let path (RootPath p) = p
 
 type Doc =
     { path: PathUri

--- a/Marksman/Workspace.fsi
+++ b/Marksman/Workspace.fsi
@@ -14,6 +14,8 @@ open Marksman.Text
 type Doc =
     member Id: DocId
 
+    interface System.IComparable
+
 module Doc =
     val id: Doc -> DocId
     val uri: Doc -> DocumentUri
@@ -50,7 +52,7 @@ module Folder =
     val tryLoad: userConfig: option<Config> -> name: string -> FolderId -> option<Folder>
 
     val singleFile: doc: Doc -> config: option<Config> -> Folder
-    val multiFile: name: string -> FolderId -> docs: Map<RelPath, Doc> -> config: option<Config> -> Folder
+    val multiFile: name: string -> FolderId -> docs: seq<Doc> -> config: option<Config> -> Folder
     val isSingleFile: Folder -> bool
 
     val withDoc: Doc -> Folder -> Folder

--- a/Marksman/Workspace.fsi
+++ b/Marksman/Workspace.fsi
@@ -58,6 +58,7 @@ module Folder =
     val closeDoc: DocId -> Folder -> option<Folder>
 
     val tryFindDocByPath: AbsPath -> Folder -> option<Doc>
+    val tryFindDocByRelPath: RelPath -> Folder -> option<Doc>
     val tryFindDocByUrl: string -> Folder -> option<Doc>
     val filterDocsBySlug: Slug -> Folder -> seq<Doc>
 

--- a/Marksman/Workspace.fsi
+++ b/Marksman/Workspace.fsi
@@ -7,21 +7,19 @@ open Marksman.Cst
 open Marksman.Index
 open Marksman.Misc
 open Marksman.Paths
+open Marksman.Names
 open Marksman.Text
 
 [<Sealed>]
-type FolderId =
-    interface System.IComparable
-
-module FolderId =
-    val ofPath: PathUri -> FolderId
-
-type Doc
+type Doc =
+    member Id: DocId
 
 module Doc =
+    val id: Doc -> DocId
+    val uri: Doc -> DocumentUri
     val rootPath: Doc -> RootPath
-    val path: Doc -> PathUri
-    val pathFromRoot: Doc -> string
+    val path: Doc -> AbsPath
+    val pathFromRoot: Doc -> RelPath
     val text: Doc -> Text
     val version: Doc -> option<int>
     val cst: Doc -> Cst
@@ -29,12 +27,11 @@ module Doc =
     val name: Doc -> string
     val slug: Doc -> Slug
     val index: Doc -> Index
-    val uri: Doc -> DocumentUri
 
-    val tryLoad: root: RootPath -> path: PathUri -> option<Doc>
+    val tryLoad: FolderId -> path: LocalPath -> option<Doc>
 
-    val mk: path: PathUri -> rootPath: RootPath -> version: option<int> -> Text -> Doc
-    val fromLsp: root: RootPath -> TextDocumentItem -> Doc
+    val mk: DocId -> version: option<int> -> Text -> Doc
+    val fromLsp: FolderId -> TextDocumentItem -> Doc
     val applyLspChange: DidChangeTextDocumentParams -> Doc -> Doc
 
 type Folder
@@ -50,17 +47,17 @@ module Folder =
     val docs: Folder -> seq<Doc>
     val docCount: Folder -> int
 
-    val tryLoad: userConfig: option<Config> -> name: string -> root: RootPath -> option<Folder>
+    val tryLoad: userConfig: option<Config> -> name: string -> FolderId -> option<Folder>
 
     val singleFile: doc: Doc -> config: option<Config> -> Folder
-    val multiFile: name: string -> root: RootPath -> docs: Map<PathUri, Doc> -> config: option<Config> -> Folder
+    val multiFile: name: string -> FolderId -> docs: Map<RelPath, Doc> -> config: option<Config> -> Folder
     val isSingleFile: Folder -> bool
 
     val withDoc: Doc -> Folder -> Folder
-    val withoutDoc: PathUri -> Folder -> option<Folder>
-    val closeDoc: PathUri -> Folder -> option<Folder>
+    val withoutDoc: DocId -> Folder -> option<Folder>
+    val closeDoc: DocId -> Folder -> option<Folder>
 
-    val tryFindDocByPath: PathUri -> Folder -> option<Doc>
+    val tryFindDocByPath: AbsPath -> Folder -> option<Doc>
     val tryFindDocByUrl: string -> Folder -> option<Doc>
     val filterDocsBySlug: Slug -> Folder -> seq<Doc>
 
@@ -79,4 +76,4 @@ module Workspace =
     val withoutFolder: FolderId -> Workspace -> Workspace
     val withoutFolders: seq<FolderId> -> Workspace -> Workspace
 
-    val tryFindFolderEnclosing: PathUri -> Workspace -> option<Folder>
+    val tryFindFolderEnclosing: AbsPath -> Workspace -> option<Folder>

--- a/Marksman/Workspace.fsi
+++ b/Marksman/Workspace.fsi
@@ -61,6 +61,7 @@ module Folder =
     val tryFindDocByRelPath: RelPath -> Folder -> option<Doc>
     val tryFindDocByUrl: string -> Folder -> option<Doc>
     val filterDocsBySlug: Slug -> Folder -> seq<Doc>
+    val filterDocsByInternPath: InternPath -> Folder -> seq<Doc>
 
 type Workspace
 

--- a/Marksman/Workspace.fsi
+++ b/Marksman/Workspace.fsi
@@ -2,10 +2,11 @@ module Marksman.Workspace
 
 open Ionide.LanguageServerProtocol.Types
 
-open Marksman.Misc
 open Marksman.Config
 open Marksman.Cst
 open Marksman.Index
+open Marksman.Misc
+open Marksman.Paths
 open Marksman.Text
 
 [<Sealed>]
@@ -14,15 +15,6 @@ type FolderId =
 
 module FolderId =
     val ofPath: PathUri -> FolderId
-
-[<Sealed>]
-type RootPath =
-    interface System.IComparable
-
-module RootPath =
-    val ofPath: PathUri -> RootPath
-    val ofString: string -> RootPath
-    val path: RootPath -> PathUri
 
 type Doc
 

--- a/Tests/ComplTests.fs
+++ b/Tests/ComplTests.fs
@@ -8,7 +8,6 @@ open Snapper
 open Marksman.Helpers
 open Marksman.Compl
 open Marksman.Misc
-open Marksman.Workspace
 
 let tryParsePartialElement text line col = PartialElement.inText text (Position.Mk(line, col))
 let parsePartialElement text line col = tryParsePartialElement text line col |> Option.get
@@ -306,15 +305,15 @@ module Candidates =
 
     [<Fact>]
     let noDupsOnAchor_intraFile () =
-        checkSnapshot (findCandidates globalFolder (Doc.path globalDoc1) (Position.Mk(1, 3)))
+        checkSnapshot (findCandidatesInDoc globalFolder globalDoc1 (Position.Mk(1, 3)))
 
     [<Fact>]
     let noDupsOnAchor_crossFile () =
-        checkSnapshot (findCandidates globalFolder (Doc.path globalDoc2) (Position.Mk(1, 5)))
+        checkSnapshot (findCandidatesInDoc globalFolder globalDoc2 (Position.Mk(1, 5)))
 
     [<Fact>]
     let fileWithSpaces_anchor () =
-        checkSnapshot (findCandidates globalFolder (Doc.path globalDoc1) (Position.Mk(6, 15)))
+        checkSnapshot (findCandidatesInDoc globalFolder globalDoc1 (Position.Mk(6, 15)))
 
     [<Fact>]
     let docAndHeadingFuzzy () =
@@ -330,7 +329,7 @@ module Candidates =
 
         let folder = FakeFolder.Mk([ doc1; doc2; doc3 ])
 
-        checkSnapshot (findCandidates folder (Doc.path doc1) (Position.Mk(1, 5)))
+        checkSnapshot (findCandidatesInDoc folder doc1 (Position.Mk(1, 5)))
 
     [<Fact>]
     let referenceEmptyBrackets () =
@@ -342,7 +341,7 @@ module Candidates =
 
         let folder = FakeFolder.Mk([ doc1 ])
 
-        checkSnapshot (findCandidates folder (Doc.path doc1) (Position.Mk(1, 1)))
+        checkSnapshot (findCandidatesInDoc folder doc1 (Position.Mk(1, 1)))
 
     [<Fact>]
     let referenceNonEmptyBrackets () =
@@ -354,7 +353,7 @@ module Candidates =
 
         let folder = FakeFolder.Mk([ doc1 ])
 
-        checkSnapshot (findCandidates folder (Doc.path doc1) (Position.Mk(1, 2)))
+        checkSnapshot (findCandidatesInDoc folder doc1 (Position.Mk(1, 2)))
 
     [<Fact>]
     let inlineEmpty () =
@@ -365,7 +364,7 @@ module Candidates =
         let doc3 = FakeDoc.Mk(path = "doc3.md", contentLines = [| "# Doc 3" |])
         let folder = FakeFolder.Mk([ doc1; doc2; doc3 ])
 
-        checkSnapshot (findCandidates folder (Doc.path doc1) (Position.Mk(1, 3)))
+        checkSnapshot (findCandidatesInDoc folder doc1 (Position.Mk(1, 3)))
 
     [<Fact>]
     let partialWikiDoc () =
@@ -376,7 +375,7 @@ module Candidates =
         let doc3 = FakeDoc.Mk(path = "doc3.md", contentLines = [| "# Doc 3" |])
         let folder = FakeFolder.Mk([ doc1; doc2; doc3 ])
 
-        checkSnapshot (findCandidates folder (Doc.path doc1) (Position.Mk(1, 2)))
+        checkSnapshot (findCandidatesInDoc folder doc1 (Position.Mk(1, 2)))
 
     [<Fact>]
     let partialWikiHeading () =
@@ -388,7 +387,7 @@ module Candidates =
 
         let folder = FakeFolder.Mk([ doc1 ])
 
-        checkSnapshot (findCandidates folder (Doc.path doc1) (Position.Mk(1, 3)))
+        checkSnapshot (findCandidatesInDoc folder doc1 (Position.Mk(1, 3)))
 
     [<Fact>]
     let partialWikiDocHeading () =
@@ -403,7 +402,7 @@ module Candidates =
 
         let folder = FakeFolder.Mk([ doc1; doc2; doc3 ])
 
-        checkSnapshot (findCandidates folder (Doc.path doc1) (Position.Mk(1, 4)))
+        checkSnapshot (findCandidatesInDoc folder doc1 (Position.Mk(1, 4)))
 
 
     [<Fact>]
@@ -422,7 +421,7 @@ module Candidates =
 
         let folder = FakeFolder.Mk([ doc1; doc2; doc3 ], config = config)
 
-        checkSnapshot (findCandidates folder (Doc.path doc1) (Position.Mk(1, 4)))
+        checkSnapshot (findCandidatesInDoc folder doc1 (Position.Mk(1, 4)))
 
 
     [<Fact>]
@@ -441,7 +440,7 @@ module Candidates =
 
         let folder = FakeFolder.Mk([ doc1; doc2; doc3 ], config = config)
 
-        checkSnapshot (findCandidates folder (Doc.path doc1) (Position.Mk(1, 4)))
+        checkSnapshot (findCandidatesInDoc folder doc1 (Position.Mk(1, 4)))
 
     [<Fact>]
     let partialWikiDoc_FileStem_ArbitraryPath () =
@@ -453,7 +452,7 @@ module Candidates =
 
         let folder = FakeFolder.Mk([ doc1; doc2 ])
 
-        checkSnapshot (findCandidates folder (Doc.path doc1) (Position.Mk(1, 5)))
+        checkSnapshot (findCandidatesInDoc folder doc1 (Position.Mk(1, 5)))
 
     [<Fact>]
     let partialReferenceEmpty () =
@@ -465,7 +464,7 @@ module Candidates =
 
         let folder = FakeFolder.Mk([ doc1 ])
 
-        checkSnapshot (findCandidates folder (Doc.path doc1) (Position.Mk(1, 1)))
+        checkSnapshot (findCandidatesInDoc folder doc1 (Position.Mk(1, 1)))
 
     [<Fact>]
     let partialInlineHeading () =
@@ -477,7 +476,7 @@ module Candidates =
 
         let folder = FakeFolder.Mk([ doc1 ])
 
-        checkSnapshot (findCandidates folder (Doc.path doc1) (Position.Mk(1, 8)))
+        checkSnapshot (findCandidatesInDoc folder doc1 (Position.Mk(1, 8)))
 
     [<Fact>]
     let partialInlineDoc () =
@@ -488,7 +487,7 @@ module Candidates =
         let doc3 = FakeDoc.Mk(path = "doc3.md", contentLines = [| "# Doc 3" |])
         let folder = FakeFolder.Mk([ doc1; doc2; doc3 ])
 
-        checkSnapshot (findCandidates folder (Doc.path doc1) (Position.Mk(1, 3)))
+        checkSnapshot (findCandidatesInDoc folder doc1 (Position.Mk(1, 3)))
 
     [<StoreSnapshotsPerClass>]
     module WikiWithSpaces_TitleSlug =
@@ -503,15 +502,15 @@ module Candidates =
 
         [<Fact>]
         let test1 () =
-            checkSnapshot (findCandidates folder (Doc.path doc4) (Position.Mk(0, 3)))
+            checkSnapshot (findCandidatesInDoc folder doc4 (Position.Mk(0, 3)))
 
         [<Fact>]
         let test2 () =
-            checkSnapshot (findCandidates folder (Doc.path doc4) (Position.Mk(1, 5)))
+            checkSnapshot (findCandidatesInDoc folder doc4 (Position.Mk(1, 5)))
 
         [<Fact>]
         let test3 () =
-            checkSnapshot (findCandidates folder (Doc.path doc4) (Position.Mk(2, 5)))
+            checkSnapshot (findCandidatesInDoc folder doc4 (Position.Mk(2, 5)))
 
     [<StoreSnapshotsPerClass>]
     module WikiWithSpaces_FileStem =
@@ -532,15 +531,15 @@ module Candidates =
 
         [<Fact>]
         let test1 () =
-            checkSnapshot (findCandidates folder (Doc.path doc4) (Position.Mk(0, 4)))
+            checkSnapshot (findCandidatesInDoc folder doc4 (Position.Mk(0, 4)))
 
         [<Fact>]
         let test2 () =
-            checkSnapshot (findCandidates folder (Doc.path doc4) (Position.Mk(1, 7)))
+            checkSnapshot (findCandidatesInDoc folder doc4 (Position.Mk(1, 7)))
 
         [<Fact>]
         let test3 () =
-            checkSnapshot (findCandidates folder (Doc.path doc4) (Position.Mk(2, 5)))
+            checkSnapshot (findCandidatesInDoc folder doc4 (Position.Mk(2, 5)))
             
     [<Fact>]
     let wiki_HeadingWithSpecialChars_NotEncoded () =
@@ -554,7 +553,7 @@ module Candidates =
                 "[[#f"
                 "" |])
         let folder = FakeFolder.Mk([doc1])
-        checkSnapshot (findCandidates folder (Doc.path doc1) (Position.Mk(3, 4)))
+        checkSnapshot (findCandidatesInDoc folder doc1 (Position.Mk(3, 4)))
 
     [<Fact>]
     // # has a special meaning in URIs. Because of this Uri library doesn't handle
@@ -576,7 +575,7 @@ module Candidates =
 
         let folder = FakeFolder.Mk([ doc1; doc2 ], config)
 
-        checkSnapshot (findCandidates folder (Doc.path doc2) (Position.Mk(0, 14)))
+        checkSnapshot (findCandidatesInDoc folder doc2 (Position.Mk(0, 14)))
 
     [<StoreSnapshotsPerClass>]
     module Tags =
@@ -598,8 +597,8 @@ module Candidates =
 
         [<Fact>]
         let tagOpening () =
-            checkSnapshot (findCandidates folder (Doc.path doc1) (Position.Mk(1, 16)))
+            checkSnapshot (findCandidatesInDoc folder doc1 (Position.Mk(1, 16)))
 
         [<Fact>]
         let tagWithName () =
-            checkSnapshot (findCandidates folder (Doc.path doc1) (Position.Mk(2, 15)))
+            checkSnapshot (findCandidatesInDoc folder doc1 (Position.Mk(2, 15)))

--- a/Tests/ComplTests.fs
+++ b/Tests/ComplTests.fs
@@ -501,16 +501,13 @@ module Candidates =
         let folder = FakeFolder.Mk([ doc1; doc2; doc3; doc4 ])
 
         [<Fact>]
-        let test1 () =
-            checkSnapshot (findCandidatesInDoc folder doc4 (Position.Mk(0, 3)))
+        let test1 () = checkSnapshot (findCandidatesInDoc folder doc4 (Position.Mk(0, 3)))
 
         [<Fact>]
-        let test2 () =
-            checkSnapshot (findCandidatesInDoc folder doc4 (Position.Mk(1, 5)))
+        let test2 () = checkSnapshot (findCandidatesInDoc folder doc4 (Position.Mk(1, 5)))
 
         [<Fact>]
-        let test3 () =
-            checkSnapshot (findCandidatesInDoc folder doc4 (Position.Mk(2, 5)))
+        let test3 () = checkSnapshot (findCandidatesInDoc folder doc4 (Position.Mk(2, 5)))
 
     [<StoreSnapshotsPerClass>]
     module WikiWithSpaces_FileStem =
@@ -530,29 +527,29 @@ module Candidates =
             )
 
         [<Fact>]
-        let test1 () =
-            checkSnapshot (findCandidatesInDoc folder doc4 (Position.Mk(0, 4)))
+        let test1 () = checkSnapshot (findCandidatesInDoc folder doc4 (Position.Mk(0, 4)))
 
         [<Fact>]
-        let test2 () =
-            checkSnapshot (findCandidatesInDoc folder doc4 (Position.Mk(1, 7)))
+        let test2 () = checkSnapshot (findCandidatesInDoc folder doc4 (Position.Mk(1, 7)))
 
         [<Fact>]
-        let test3 () =
-            checkSnapshot (findCandidatesInDoc folder doc4 (Position.Mk(2, 5)))
-            
+        let test3 () = checkSnapshot (findCandidatesInDoc folder doc4 (Position.Mk(2, 5)))
+
     [<Fact>]
     let wiki_HeadingWithSpecialChars_NotEncoded () =
-        let doc1 = FakeDoc.Mk(
-            path = "doc1.md",
-            contentLines = [|
-                "# Doc 1"
-                "## Foo / Bar"
-                "## Baz"
-                //1234
-                "[[#f"
-                "" |])
-        let folder = FakeFolder.Mk([doc1])
+        let doc1 =
+            FakeDoc.Mk(
+                path = "doc1.md",
+                contentLines =
+                    [| "# Doc 1"
+                       "## Foo / Bar"
+                       "## Baz"
+                       //1234
+                       "[[#f"
+                       "" |]
+            )
+
+        let folder = FakeFolder.Mk([ doc1 ])
         checkSnapshot (findCandidatesInDoc folder doc1 (Position.Mk(3, 4)))
 
     [<Fact>]
@@ -596,9 +593,7 @@ module Candidates =
         let folder = FakeFolder.Mk([ doc1; doc2 ])
 
         [<Fact>]
-        let tagOpening () =
-            checkSnapshot (findCandidatesInDoc folder doc1 (Position.Mk(1, 16)))
+        let tagOpening () = checkSnapshot (findCandidatesInDoc folder doc1 (Position.Mk(1, 16)))
 
         [<Fact>]
-        let tagWithName () =
-            checkSnapshot (findCandidatesInDoc folder doc1 (Position.Mk(2, 15)))
+        let tagWithName () = checkSnapshot (findCandidatesInDoc folder doc1 (Position.Mk(2, 15)))

--- a/Tests/DiagTest.fs
+++ b/Tests/DiagTest.fs
@@ -1,13 +1,13 @@
 module Marksman.DiagTest
 
 open System.IO
-open Marksman.Index
-open Marksman.Misc
 open Xunit
 
-open Marksman.Workspace
 open Marksman.Diag
 open Marksman.Helpers
+open Marksman.Index
+open Marksman.Paths
+open Marksman.Workspace
 
 let entryToHuman (entry: Entry) =
     let lsp = diagToLsp entry

--- a/Tests/DiagTest.fs
+++ b/Tests/DiagTest.fs
@@ -1,11 +1,11 @@
 module Marksman.DiagTest
 
-open System.IO
 open Xunit
 
 open Marksman.Diag
 open Marksman.Helpers
 open Marksman.Index
+open Marksman.Names
 open Marksman.Paths
 open Marksman.Workspace
 
@@ -13,11 +13,11 @@ let entryToHuman (entry: Entry) =
     let lsp = diagToLsp entry
     lsp.Message
 
-let diagToHuman (diag: seq<PathUri * list<Entry>>) : list<string * string> =
+let diagToHuman (diag: seq<DocId * list<Entry>>) : list<string * string> =
     seq {
-        for path, entries in diag do
+        for id, entries in diag do
             for e in entries do
-                yield Path.GetFileName path.LocalPath, entryToHuman e
+                yield id.data.path |> RelPath.toSystem, entryToHuman e
     }
     |> List.ofSeq
 

--- a/Tests/DiagTest.fs
+++ b/Tests/DiagTest.fs
@@ -88,13 +88,10 @@ let noDiagOnNonMarkdownFiles () =
 let crossFileDiagOnBrokenWikiLinks () =
     let doc = FakeDoc.Mk([| "[[bad]]" |])
 
-    let folder = FakeFolder.Mk([doc])
+    let folder = FakeFolder.Mk([ doc ])
     let diag = checkFolder folder |> diagToHuman
 
-    Assert.Equal<string * string>(
-        [ "fake.md", "Link to non-existent document 'bad'" ],
-        diag
-    )
+    Assert.Equal<string * string>([ "fake.md", "Link to non-existent document 'bad'" ], diag)
 
 [<Fact>]
 let noCrossFileDiagOnSingleFileFolders () =

--- a/Tests/Helpers.fs
+++ b/Tests/Helpers.fs
@@ -71,9 +71,6 @@ type FakeDoc =
 type FakeFolder =
     class
         static member Mk(docs: seq<Doc>, ?config: Config.Config) : Folder =
-            let docsMap =
-                docs |> Seq.map (fun d -> Doc.pathFromRoot d, d) |> Map.ofSeq
-
             let folderId = UriWith.mkRoot dummyRootUri
-            Folder.multiFile "dummy" folderId docsMap config
+            Folder.multiFile "dummy" folderId docs config
     end

--- a/Tests/Helpers.fs
+++ b/Tests/Helpers.fs
@@ -21,6 +21,15 @@ let dummyRootPath pathComps = dummyRoot + (pathComps |> String.concat "/")
 
 let pathComps (path: string) = path.TrimStart('/').Split("/") |> List.ofArray
 
+let mkFolderId str =
+    let root = AbsPath.ofSystem str
+    let uri = AbsPath.toUri root
+    UriWith.mkRoot uri
+
+let mkDocId folderId str =
+    let path = LocalPath.ofSystem str
+    UriWith.mkRooted folderId path
+ 
 let checkInlineSnapshot (fmt: 'a -> string) (things: seq<'a>) (snapshot: seq<string>) =
     let lines = Seq.map (fun x -> (fmt x).Lines()) things |> Seq.concat
 
@@ -48,8 +57,9 @@ type FakeDoc =
             let pathUri = pathToUri (dummyRootPath (pathComps path))
             let root = Option.map pathComps root |> Option.defaultValue []
             let rootUri = dummyRootPath root |> pathToUri
+            let docId = UriWith.mkRooted (UriWith.mkRoot rootUri) (LocalPath.ofUri pathUri)
 
-            Doc.mk (PathUri.ofString pathUri) (RootPath.ofString rootUri) None text
+            Doc.mk docId None text
 
         static member Mk(contentLines: array<string>, ?path: string) : Doc =
             let content = String.concat System.Environment.NewLine contentLines
@@ -59,7 +69,7 @@ type FakeDoc =
 type FakeFolder =
     class
         static member Mk(docs: seq<Doc>, ?config: Config.Config) : Folder =
-            let docsMap = docs |> Seq.map (fun d -> Doc.path d, d) |> Map.ofSeq
-
-            Folder.multiFile "dummy" (RootPath.ofString dummyRootUri) docsMap config
+            let docsMap = docs |> Seq.map (fun d -> Doc.pathFromRoot d, d) |> Map.ofSeq
+            let folderId = UriWith.mkRoot dummyRootUri
+            Folder.multiFile "dummy" folderId docsMap config
     end

--- a/Tests/Helpers.fs
+++ b/Tests/Helpers.fs
@@ -29,7 +29,7 @@ let mkFolderId str =
 let mkDocId folderId str =
     let path = LocalPath.ofSystem str
     UriWith.mkRooted folderId path
- 
+
 let checkInlineSnapshot (fmt: 'a -> string) (things: seq<'a>) (snapshot: seq<string>) =
     let lines = Seq.map (fun x -> (fmt x).Lines()) things |> Seq.concat
 
@@ -57,7 +57,9 @@ type FakeDoc =
             let pathUri = pathToUri (dummyRootPath (pathComps path))
             let root = Option.map pathComps root |> Option.defaultValue []
             let rootUri = dummyRootPath root |> pathToUri
-            let docId = UriWith.mkRooted (UriWith.mkRoot rootUri) (LocalPath.ofUri pathUri)
+
+            let docId =
+                UriWith.mkRooted (UriWith.mkRoot rootUri) (LocalPath.ofUri pathUri)
 
             Doc.mk docId None text
 
@@ -69,7 +71,9 @@ type FakeDoc =
 type FakeFolder =
     class
         static member Mk(docs: seq<Doc>, ?config: Config.Config) : Folder =
-            let docsMap = docs |> Seq.map (fun d -> Doc.pathFromRoot d, d) |> Map.ofSeq
+            let docsMap =
+                docs |> Seq.map (fun d -> Doc.pathFromRoot d, d) |> Map.ofSeq
+
             let folderId = UriWith.mkRoot dummyRootUri
             Folder.multiFile "dummy" folderId docsMap config
     end

--- a/Tests/Helpers.fs
+++ b/Tests/Helpers.fs
@@ -3,6 +3,7 @@ module Marksman.Helpers
 open System.Runtime.InteropServices
 open Snapper
 open Marksman.Misc
+open Marksman.Paths
 open Marksman.Workspace
 open Marksman.CodeActions
 

--- a/Tests/MiscTests.fs
+++ b/Tests/MiscTests.fs
@@ -2,7 +2,7 @@ module Marksman.MiscTests
 
 open Xunit
 
-open Misc
+open Marksman.Misc
 
 module StringExtensionsTests =
     [<Fact>]
@@ -98,33 +98,6 @@ module StringExtensionsTests =
         let actual = original.EncodeForWiki()
         Assert.Equal(expected, actual)
         Assert.Equal(original, actual.UrlDecode())
-
-module PathUriTests =
-    [<Fact>]
-    let testWinPathFromUri () =
-        let uri = "file:///e%3A/notes"
-        let puri = PathUri.ofString uri
-
-        Assert.Equal("e:\\notes", puri.LocalPath)
-
-    [<Fact>]
-    let testWinPathFromPath () =
-        let puri = PathUri.ofString "E:\\notes (precious)"
-
-        Assert.Equal("e:\\notes (precious)", puri.LocalPath)
-
-    [<Fact>]
-    let testWinDocUriFromUri () =
-        let uri = "file:///e%3A/notes"
-        let puri = PathUri.ofString uri
-        Assert.Equal(uri, puri.DocumentUri)
-
-    [<Fact>]
-    let testWinDocUriFromPath () =
-        let path = "E:\\notes"
-        let uri = "file:///e%3A/notes"
-        let puri = PathUri.ofString path
-        Assert.Equal(uri, puri.DocumentUri)
 
 module LinkLabelTest =
     [<Fact>]

--- a/Tests/MiscTests.fs
+++ b/Tests/MiscTests.fs
@@ -118,7 +118,12 @@ module WatchGlobTest =
 
 module SuffixTreeTests =
     let tree =
-        SuffixTree.ofSeq [ [ "a"; "b"; "c" ], 1; [ "a"; "b"; "d" ], 2; [ "b" ], 3; [ "c" ], 4 ]
+        SuffixTree.ofSeq
+            [ [ "a"; "b" ], 0
+              [ "a"; "b"; "c" ], 1
+              [ "a"; "b"; "d" ], 2
+              [ "b" ], 3
+              [ "c" ], 4 ]
 
     [<Fact>]
     let filterTest () =
@@ -140,3 +145,24 @@ module SuffixTreeTests =
             SuffixTree.filterMatchingValues [ "b"; "z" ] tree |> List.ofSeq
 
         Assert.Equal<int>([], actual)
+
+    [<Fact>]
+    let removeTest () =
+        let actual =
+            SuffixTree.remove [ "a"; "b"; "c" ] tree |> SuffixTree.collectValues
+
+        Assert.Equal([ 3; 0; 4; 2 ], actual)
+
+        let actual =
+            SuffixTree.remove [ "a"; "b"; "z" ] tree |> SuffixTree.collectValues
+
+        Assert.Equal([ 3; 0; 4; 1; 2 ], actual)
+
+        let actual = SuffixTree.remove [ "c" ] tree |> SuffixTree.collectValues
+
+        Assert.Equal([ 3; 0; 1; 2 ], actual)
+
+        let actual =
+            SuffixTree.remove [ "a"; "b" ] tree |> SuffixTree.collectValues
+
+        Assert.Equal([ 3; 4; 1; 2 ], actual)

--- a/Tests/MiscTests.fs
+++ b/Tests/MiscTests.fs
@@ -115,3 +115,28 @@ module WatchGlobTest =
     [<Fact>]
     let test1 () =
         Assert.Equal("**/*.{md,markdown,mdx}", mkWatchGlob [| "md"; "markdown"; "mdx" |])
+
+module SuffixTreeTests =
+    let tree =
+        SuffixTree.ofSeq [ [ "a"; "b"; "c" ], 1; [ "a"; "b"; "d" ], 2; [ "b" ], 3; [ "c" ], 4 ]
+
+    [<Fact>]
+    let filterTest () =
+        let actual = SuffixTree.filterMatchingValues [ "c" ] tree |> List.ofSeq
+        Assert.Equal<int>([ 4; 1 ], actual)
+
+        let actual = SuffixTree.filterMatchingValues [ "d" ] tree |> List.ofSeq
+        Assert.Equal<int>([ 2 ], actual)
+
+        let actual =
+            SuffixTree.filterMatchingValues [ "b"; "c" ] tree |> List.ofSeq
+
+        Assert.Equal<int>([ 1 ], actual)
+
+        let actual = SuffixTree.filterMatchingValues [ "e" ] tree |> List.ofSeq
+        Assert.Equal<int>([], actual)
+
+        let actual =
+            SuffixTree.filterMatchingValues [ "b"; "z" ] tree |> List.ofSeq
+
+        Assert.Equal<int>([], actual)

--- a/Tests/ParserTests.fs
+++ b/Tests/ParserTests.fs
@@ -340,7 +340,8 @@ module TagsTests =
               "T: name=tag2; range=(0,7)-(0,11) @ (0,6)-(0,11)" ]
 
 module DocUrlTests =
-    let mkUrlNode str = Node.mk str (Range.Mk(0, 0, 0, str.Length)) (UrlEncoded.mkUnchecked str)
+    let mkUrlNode str =
+        Node.mk str (Range.Mk(0, 0, 0, str.Length)) (UrlEncoded.mkUnchecked str)
 
     [<Fact>]
     let test1 () =

--- a/Tests/ParserTests.fs
+++ b/Tests/ParserTests.fs
@@ -2,6 +2,7 @@ module Marksman.ParserTests
 
 open Ionide.LanguageServerProtocol.Types
 
+open Marksman.Names
 open Snapper
 open Snapper.Attributes
 open Xunit
@@ -339,16 +340,16 @@ module TagsTests =
               "T: name=tag2; range=(0,7)-(0,11) @ (0,6)-(0,11)" ]
 
 module DocUrlTests =
-    let mkTextNode str = Node.mkText str (Range.Mk(0, 0, 0, str.Length))
+    let mkUrlNode str = Node.mk str (Range.Mk(0, 0, 0, str.Length)) (UrlEncoded.mkUnchecked str)
 
     [<Fact>]
     let test1 () =
-        let actual = mkTextNode "/some.md" |> Url.ofUrlNode
+        let actual = mkUrlNode "/some.md" |> Url.ofUrlNode
         Assert.Equal("docUrl=/some.md @ (0,0)-(0,8)", actual.ToString())
 
     [<Fact>]
     let test2 () =
-        let actual = mkTextNode "/some.md#anchor" |> Url.ofUrlNode
+        let actual = mkUrlNode "/some.md#anchor" |> Url.ofUrlNode
 
         Assert.Equal(
             "docUrl=/some.md @ (0,0)-(0,8);anchor=anchor @ (0,9)-(0,15)",
@@ -358,7 +359,7 @@ module DocUrlTests =
     [<Fact>]
     let test3 () =
         //                       01234567
-        let actual = mkTextNode "#anchor" |> Url.ofUrlNode
+        let actual = mkUrlNode "#anchor" |> Url.ofUrlNode
 
         Assert.Equal("anchor=anchor @ (0,1)-(0,7)", actual.ToString())
 

--- a/Tests/PathsTests.fs
+++ b/Tests/PathsTests.fs
@@ -9,52 +9,56 @@ module LocalPathTests =
     let testWinPath () =
         let p = LocalPath.ofSystem "C:/Program Data"
         Assert.Equal("C:/Program Data", LocalPath.toSystem p)
-        Assert.Equal<string>([|"C:"; "Program Data"|], LocalPath.components p)
-        
+        Assert.Equal<string>([| "C:"; "Program Data" |], LocalPath.components p)
+
         let p = LocalPath.ofSystem "C:\\Program Data\\notes.txt"
         Assert.Equal("C:\\Program Data\\notes.txt", LocalPath.toSystem p)
-        Assert.Equal<string>([|"C:"; "Program Data"; "notes.txt"|], LocalPath.components p)
-        
+        Assert.Equal<string>([| "C:"; "Program Data"; "notes.txt" |], LocalPath.components p)
+
     [<Fact>]
     let testUnixPath () =
         let p = LocalPath.ofSystem "/"
         Assert.Equal("/", LocalPath.toSystem p)
         Assert.Equal<string>([||], LocalPath.components p)
-        
+
         let p = LocalPath.ofSystem "/home/user"
         Assert.Equal("/home/user", LocalPath.toSystem p)
-        Assert.Equal<string>([|"home"; "user"|], LocalPath.components p)
-        
+        Assert.Equal<string>([| "home"; "user" |], LocalPath.components p)
+
         let p = LocalPath.ofSystem "/home/user/"
         Assert.Equal("/home/user/", LocalPath.toSystem p)
-        Assert.Equal<string>([|"home"; "user"|], LocalPath.components p)
-        
+        Assert.Equal<string>([| "home"; "user" |], LocalPath.components p)
+
         let p = LocalPath.ofSystem "/home/user/data/../notes/notes.txt"
         Assert.Equal("/home/user/data/../notes/notes.txt", LocalPath.toSystem p)
-        Assert.Equal<string>([|"home"; "user"; "data"; ".."; "notes"; "notes.txt"|], LocalPath.components p)
-        
+
+        Assert.Equal<string>(
+            [| "home"; "user"; "data"; ".."; "notes"; "notes.txt" |],
+            LocalPath.components p
+        )
+
     [<Fact>]
     let testNormalize () =
         let p = LocalPath.ofSystem "/home/user/data/../notes/notes.txt"
         let np = LocalPath.normalize p
         Assert.Equal("/home/user/notes/notes.txt", LocalPath.toSystem np)
-        
+
         let p = LocalPath.ofSystem "/../../notes/notes.txt"
         let np = LocalPath.normalize p
         Assert.Equal("/notes/notes.txt", LocalPath.toSystem np)
-        
+
         let p = LocalPath.ofSystem "./../../notes/notes.txt"
         let np = LocalPath.normalize p
         Assert.Equal("../../notes/notes.txt", LocalPath.toSystem np)
-        
+
         let p = LocalPath.ofSystem "../data/../../notes/notes.txt"
         let np = LocalPath.normalize p
         Assert.Equal("../../notes/notes.txt", LocalPath.toSystem np)
-        
+
         let p = LocalPath.ofSystem "C:\\data\\..\\..\\notes\\notes.txt"
         let np = LocalPath.normalize p
         Assert.Equal("C:\\notes\\notes.txt", LocalPath.toSystem np)
-    
+
 module PathUriTests =
     [<Fact>]
     let testWinPathFromUri () =
@@ -81,4 +85,3 @@ module PathUriTests =
         let uri = "file:///E%3A/notes"
         let puri = UriWith.mkAbs (systemPathToUriString path)
         Assert.Equal(uri, puri.uri)
-

--- a/Tests/PathsTests.fs
+++ b/Tests/PathsTests.fs
@@ -1,0 +1,33 @@
+module Marksman.PathsTests
+
+open Xunit
+
+open Marksman.Paths
+
+module PathUriTests =
+    [<Fact>]
+    let testWinPathFromUri () =
+        let uri = "file:///e%3A/notes"
+        let puri = PathUri.ofString uri
+
+        Assert.Equal("e:\\notes", puri.LocalPath)
+
+    [<Fact>]
+    let testWinPathFromPath () =
+        let puri = PathUri.ofString "E:\\notes (precious)"
+
+        Assert.Equal("e:\\notes (precious)", puri.LocalPath)
+
+    [<Fact>]
+    let testWinDocUriFromUri () =
+        let uri = "file:///e%3A/notes"
+        let puri = PathUri.ofString uri
+        Assert.Equal(uri, puri.DocumentUri)
+
+    [<Fact>]
+    let testWinDocUriFromPath () =
+        let path = "E:\\notes"
+        let uri = "file:///e%3A/notes"
+        let puri = PathUri.ofString path
+        Assert.Equal(uri, puri.DocumentUri)
+

--- a/Tests/Program.fs
+++ b/Tests/Program.fs
@@ -1,1 +1,3 @@
-module Program = let [<EntryPoint>] main _ = 0
+module Program =
+    [<EntryPoint>]
+    let main _ = 0

--- a/Tests/RefsTests.fs
+++ b/Tests/RefsTests.fs
@@ -4,11 +4,12 @@ open Ionide.LanguageServerProtocol.Types
 open System.IO
 open Xunit
 
-open Marksman.Misc
-open Marksman.Helpers
 open Marksman.Cst
-open Marksman.Workspace
+open Marksman.Helpers
+open Marksman.Misc
+open Marksman.Paths
 open Marksman.Refs
+open Marksman.Workspace
 
 module InternNameTests =
     [<Fact>]

--- a/Tests/RefsTests.fs
+++ b/Tests/RefsTests.fs
@@ -15,7 +15,7 @@ open Marksman.Workspace
 module InternNameTests =
     let internAsPath docId name =
         InternName.tryAsPath (InternName.mkUnchecked docId name)
-        |> Option.map (fun x -> x.path |> RelPath.toSystem)
+        |> Option.map (InternPath.toRel >> RelPath.toSystem)
 
     [<Fact>]
     let relPath_1 () =
@@ -66,7 +66,7 @@ module InternNameTests =
 
         let actual = internAsPath docPath "www.google.com" |> Option.get
 
-        Assert.Equal("subfolder/www.google.com", actual)
+        Assert.Equal("www.google.com", actual)
 
     [<Fact>]
     let url_schema () =

--- a/Tests/RefsTests.fs
+++ b/Tests/RefsTests.fs
@@ -16,11 +16,15 @@ module InternNameTests =
     let internAsPath docId name =
         InternName.tryAsPath (InternName.mkUnchecked docId name)
         |> Option.map (fun x -> x.path |> RelPath.toSystem)
-    
+
     [<Fact>]
     let relPath_1 () =
         let folder = dummyRootPath [ "rootFolder" ] |> mkFolderId
-        let docPath = dummyRootPath [ "rootFolder"; "subfolder"; "sub.md" ] |> mkDocId folder
+
+        let docPath =
+            dummyRootPath [ "rootFolder"; "subfolder"; "sub.md" ]
+            |> mkDocId folder
+
         let actual = internAsPath docPath "../doc.md" |> Option.get
 
         Assert.Equal("doc.md", actual)
@@ -43,7 +47,11 @@ module InternNameTests =
     [<Fact>]
     let rootPath () =
         let folder = dummyRootPath [ "rootFolder" ] |> mkFolderId
-        let docPath = dummyRootPath [ "rootFolder"; "subfolder"; "sub.md" ] |> mkDocId folder
+
+        let docPath =
+            dummyRootPath [ "rootFolder"; "subfolder"; "sub.md" ]
+            |> mkDocId folder
+
         let actual = internAsPath docPath "/doc.md" |> Option.get
 
         Assert.Equal("doc.md", actual)
@@ -51,7 +59,11 @@ module InternNameTests =
     [<Fact>]
     let url_no_schema_FP () =
         let folder = dummyRootPath [ "rootFolder" ] |> mkFolderId
-        let docPath = dummyRootPath [ "rootFolder"; "subfolder"; "sub.md" ] |> mkDocId folder
+
+        let docPath =
+            dummyRootPath [ "rootFolder"; "subfolder"; "sub.md" ]
+            |> mkDocId folder
+
         let actual = internAsPath docPath "www.google.com" |> Option.get
 
         Assert.Equal("subfolder/www.google.com", actual)
@@ -59,7 +71,11 @@ module InternNameTests =
     [<Fact>]
     let url_schema () =
         let folder = dummyRootPath [ "rootFolder" ] |> mkFolderId
-        let docPath = dummyRootPath [ "rootFolder"; "subfolder"; "sub.md" ] |> mkDocId folder
+
+        let docPath =
+            dummyRootPath [ "rootFolder"; "subfolder"; "sub.md" ]
+            |> mkDocId folder
+
         let actual = internAsPath docPath "http://www.google.com"
 
         Assert.Equal(None, actual)
@@ -76,16 +92,21 @@ let stripRefs (refs: seq<Doc * Element * array<Dest>>) =
 
 module FileLinkTests =
     let doc1 = FakeDoc.Mk(path = "doc1.md", contentLines = [| "# Horses" |])
-    let subDoc1 = FakeDoc.Mk(path = "sub/doc1.md", contentLines = [|"# Sub Horses"|])
-    let subSubDoc1 = FakeDoc.Mk(path = "sub/sub/doc1.md", contentLines = [|"# Sub Sub Horses"|])
+
+    let subDoc1 =
+        FakeDoc.Mk(path = "sub/doc1.md", contentLines = [| "# Sub Horses" |])
+
+    let subSubDoc1 =
+        FakeDoc.Mk(path = "sub/sub/doc1.md", contentLines = [| "# Sub Sub Horses" |])
 
     let doc2 =
         FakeDoc.Mk(path = "doc2.md", contentLines = [| "# Riding Horses" |])
-    let subDoc2 = FakeDoc.Mk(path = "sub/doc2.md", contentLines = [|"# Sub Riding Horses"|])
 
-    let doc3 =
-        FakeDoc.Mk(path = "doc3.md", contentLines = [| "# Fruit" |])
-        
+    let subDoc2 =
+        FakeDoc.Mk(path = "sub/doc2.md", contentLines = [| "# Sub Riding Horses" |])
+
+    let doc3 = FakeDoc.Mk(path = "doc3.md", contentLines = [| "# Fruit" |])
+
     let doc4 =
         FakeDoc.Mk(path = "file with spaces.md", contentLines = [| "# File with spaces" |])
 
@@ -97,7 +118,9 @@ module FileLinkTests =
                 { Config.Config.Default with complWikiStyle = Some Config.FileStem }
             )
 
-        let partial = FileLink.filterMatchingDocs folder (InternName.mkUnchecked doc1.Id "doc")
+        let partial =
+            FileLink.filterMatchingDocs folder (InternName.mkUnchecked doc1.Id "doc")
+
         Assert.Empty(partial)
 
         let full =
@@ -106,16 +129,20 @@ module FileLinkTests =
 
         Assert.Equal(1, full.Length)
         Assert.Equal(doc2, full[0].dest)
-        
+
         let fullWithSpacesEncoded =
-            FileLink.filterMatchingDocs folder (InternName.mkUnchecked doc2.Id "file%20with%20spaces.md")
+            FileLink.filterMatchingDocs
+                folder
+                (InternName.mkUnchecked doc2.Id "file%20with%20spaces.md")
             |> Array.ofSeq
 
         Assert.Equal(1, fullWithSpacesEncoded.Length)
         Assert.Equal(doc4, fullWithSpacesEncoded[0].dest)
-        
+
         let fullWithSpacesNotEncoded =
-            FileLink.filterMatchingDocs folder (InternName.mkUnchecked doc2.Id "file with spaces.md")
+            FileLink.filterMatchingDocs
+                folder
+                (InternName.mkUnchecked doc2.Id "file with spaces.md")
             |> Array.ofSeq
 
         Assert.Equal(1, fullWithSpacesNotEncoded.Length)
@@ -123,16 +150,32 @@ module FileLinkTests =
 
     [<Fact>]
     let fileName_RelativeAsAbs () =
-        let folder = FakeFolder.Mk([doc1; subDoc1; subSubDoc1; doc2; subDoc2], {Config.Config.Default with complWikiStyle = Some Config.FilePathStem})
-        
-        let actual = FileLink.filterMatchingDocs folder (InternName.mkUnchecked doc1.Id "doc1") |> Seq.map FileLink.dest |> Array.ofSeq
-        Assert.Equal<Doc>(actual, [|doc1; subDoc1; subSubDoc1|])
-        
-        let actual = FileLink.filterMatchingDocs folder (InternName.mkUnchecked subDoc1.Id "doc2") |> Seq.map FileLink.dest |> Array.ofSeq
-        Assert.Equal<Doc>(actual, [|doc2; subDoc2|])
-        
-        let actual = FileLink.filterMatchingDocs folder (InternName.mkUnchecked doc1.Id "sub/doc1") |> Seq.map FileLink.dest |> Array.ofSeq
-        Assert.Equal<Doc>(actual, [|subDoc1; subSubDoc1|])
+        let folder =
+            FakeFolder.Mk(
+                [ doc1; subDoc1; subSubDoc1; doc2; subDoc2 ],
+                { Config.Config.Default with complWikiStyle = Some Config.FilePathStem }
+            )
+
+        let actual =
+            FileLink.filterMatchingDocs folder (InternName.mkUnchecked doc1.Id "doc1")
+            |> Seq.map FileLink.dest
+            |> Array.ofSeq
+
+        Assert.Equal<Doc>(actual, [| doc1; subDoc1; subSubDoc1 |])
+
+        let actual =
+            FileLink.filterMatchingDocs folder (InternName.mkUnchecked subDoc1.Id "doc2")
+            |> Seq.map FileLink.dest
+            |> Array.ofSeq
+
+        Assert.Equal<Doc>(actual, [| doc2; subDoc2 |])
+
+        let actual =
+            FileLink.filterMatchingDocs folder (InternName.mkUnchecked doc1.Id "sub/doc1")
+            |> Seq.map FileLink.dest
+            |> Array.ofSeq
+
+        Assert.Equal<Doc>(actual, [| subDoc1; subSubDoc1 |])
 
     [<Fact>]
     let heading_Partial () =

--- a/Tests/SematoTests.fs
+++ b/Tests/SematoTests.fs
@@ -7,13 +7,13 @@ open Marksman.Paths
 open Marksman.Semato
 open Marksman.Workspace
 
-let folderPath = (dummyRootPath [ "folder" ]) |> RootPath.ofString
+let folderPath = (dummyRootPath [ "folder" ]) |> mkFolderId
 
 let nthToken (data: array<uint32>) n = data[n * 5 .. n * 5 + 4]
 
 [<Fact>]
 let testEncoding () =
-    let docPath = dummyRootPath [ "folder"; "doc1.md" ] |> PathUri.ofString
+    let docPath = dummyRootPath [ "folder"; "doc1.md" ] |> mkDocId folderPath
 
     let content =
         """# Title
@@ -22,7 +22,7 @@ Start with [[a-wiki-link]]. Then a [ref-link].
 <blank>
 End with [[wiki-link-no-eol]] and #tag."""
 
-    let doc = Doc.mk docPath folderPath None (Text.mkText content)
+    let doc = Doc.mk docPath None (Text.mkText content)
     let data = Token.ofIndexEncoded (Doc.index doc)
     Assert.Equal(5 * 5, data.Length)
 

--- a/Tests/SematoTests.fs
+++ b/Tests/SematoTests.fs
@@ -1,10 +1,11 @@
 module Marksman.SematoTests
 
-open Marksman.Misc
-open Marksman.Helpers
-open Marksman.Workspace
-open Marksman.Semato
 open Xunit
+
+open Marksman.Helpers
+open Marksman.Paths
+open Marksman.Semato
+open Marksman.Workspace
 
 let folderPath = (dummyRootPath [ "folder" ]) |> RootPath.ofString
 

--- a/Tests/ServerTests.fs
+++ b/Tests/ServerTests.fs
@@ -3,9 +3,10 @@ module Marksman.ServerTests
 open Xunit
 
 open Marksman.Config
+open Marksman.Paths
+open Marksman.Server
 open Marksman.State
 open Marksman.Workspace
-open Marksman.Server
 
 open Marksman.Helpers
 

--- a/Tests/ServerTests.fs
+++ b/Tests/ServerTests.fs
@@ -38,7 +38,7 @@ module ServerUtilTests =
             { ClientDescription.empty with opts = { preferredTextSyncKind = Some Incremental } }
 
         let folder =
-            Folder.multiFile "test" (dummyRootPath [ "test" ] |> mkFolderId) Map.empty None
+            Folder.multiFile "test" (dummyRootPath [ "test" ] |> mkFolderId) Seq.empty None
 
         let ws = Workspace.ofFolders None [ folder ]
         Assert.Equal(("clientOption", Incremental), ServerUtil.calcTextSync None ws clientDesc)
@@ -52,7 +52,7 @@ module ServerUtilTests =
             Folder.multiFile
                 "test"
                 (dummyRootPath [ "test" ] |> mkFolderId)
-                Map.empty
+                Seq.empty
                 (Some { Config.Empty with coreTextSync = Some Full })
 
         let ws = Workspace.ofFolders None [ folder ]

--- a/Tests/ServerTests.fs
+++ b/Tests/ServerTests.fs
@@ -33,13 +33,13 @@ module ServerUtilTests =
     [<Fact>]
     let textSync_NoConfigNonEmptyWS_PreferIncr () =
         let clientDesc = {ClientDescription.empty with opts = {preferredTextSyncKind = Some Incremental }}
-        let folder = Folder.multiFile "test" (dummyRootPath ["test"] |> RootPath.ofString) Map.empty None
+        let folder = Folder.multiFile "test" (dummyRootPath ["test"] |> mkFolderId) Map.empty None
         let ws = Workspace.ofFolders None [folder]
         Assert.Equal(("clientOption", Incremental), ServerUtil.calcTextSync None ws clientDesc)
         
     [<Fact>]
     let textSync_NonEmptyWS_PreferIncrButConfigTakesPrecedence () =
         let clientDesc = {ClientDescription.empty with opts = {preferredTextSyncKind = Some Incremental }}
-        let folder = Folder.multiFile "test" (dummyRootPath ["test"] |> RootPath.ofString) Map.empty (Some {Config.Empty with coreTextSync = Some Full })
+        let folder = Folder.multiFile "test" (dummyRootPath ["test"] |> mkFolderId) Map.empty (Some {Config.Empty with coreTextSync = Some Full })
         let ws = Workspace.ofFolders None [folder]
         Assert.Equal(("workspaceConfig", Full), ServerUtil.calcTextSync None ws clientDesc)

--- a/Tests/ServerTests.fs
+++ b/Tests/ServerTests.fs
@@ -13,33 +13,47 @@ open Marksman.Helpers
 module ServerUtilTests =
     [<Fact>]
     let textSync_UserConfigEmptyWS () =
-        let c = {Config.Default with coreTextSync = Some Incremental }
-        let clientDesc = ClientDescription.empty 
+        let c = { Config.Default with coreTextSync = Some Incremental }
+        let clientDesc = ClientDescription.empty
         let ws = Workspace.ofFolders (Some c) []
         Assert.Equal(("userConfig", Incremental), ServerUtil.calcTextSync (Some c) ws clientDesc)
-        
+
     [<Fact>]
     let textSync_NoConfigEmptyWS () =
-        let clientDesc = ClientDescription.empty 
+        let clientDesc = ClientDescription.empty
         let ws = Workspace.ofFolders None []
         Assert.Equal(("default", Full), ServerUtil.calcTextSync None ws clientDesc)
-        
+
     [<Fact>]
     let textSync_NoConfigEmptyWS_PreferIncr () =
-        let clientDesc = {ClientDescription.empty with opts = {preferredTextSyncKind = Some Incremental }}
+        let clientDesc =
+            { ClientDescription.empty with opts = { preferredTextSyncKind = Some Incremental } }
+
         let ws = Workspace.ofFolders None []
         Assert.Equal(("clientOption", Incremental), ServerUtil.calcTextSync None ws clientDesc)
-        
+
     [<Fact>]
     let textSync_NoConfigNonEmptyWS_PreferIncr () =
-        let clientDesc = {ClientDescription.empty with opts = {preferredTextSyncKind = Some Incremental }}
-        let folder = Folder.multiFile "test" (dummyRootPath ["test"] |> mkFolderId) Map.empty None
-        let ws = Workspace.ofFolders None [folder]
+        let clientDesc =
+            { ClientDescription.empty with opts = { preferredTextSyncKind = Some Incremental } }
+
+        let folder =
+            Folder.multiFile "test" (dummyRootPath [ "test" ] |> mkFolderId) Map.empty None
+
+        let ws = Workspace.ofFolders None [ folder ]
         Assert.Equal(("clientOption", Incremental), ServerUtil.calcTextSync None ws clientDesc)
-        
+
     [<Fact>]
     let textSync_NonEmptyWS_PreferIncrButConfigTakesPrecedence () =
-        let clientDesc = {ClientDescription.empty with opts = {preferredTextSyncKind = Some Incremental }}
-        let folder = Folder.multiFile "test" (dummyRootPath ["test"] |> mkFolderId) Map.empty (Some {Config.Empty with coreTextSync = Some Full })
-        let ws = Workspace.ofFolders None [folder]
+        let clientDesc =
+            { ClientDescription.empty with opts = { preferredTextSyncKind = Some Incremental } }
+
+        let folder =
+            Folder.multiFile
+                "test"
+                (dummyRootPath [ "test" ] |> mkFolderId)
+                Map.empty
+                (Some { Config.Empty with coreTextSync = Some Full })
+
+        let ws = Workspace.ofFolders None [ folder ]
         Assert.Equal(("workspaceConfig", Full), ServerUtil.calcTextSync None ws clientDesc)

--- a/Tests/StateTests.fs
+++ b/Tests/StateTests.fs
@@ -11,23 +11,22 @@ module InitOptionTests =
     let extractEmpty () =
         let json = JToken.Parse("{}")
         Assert.Equal(InitOptions.empty, InitOptions.ofJson json)
-        
+
         let json = JToken.Parse("[]")
         Assert.Equal(InitOptions.empty, InitOptions.ofJson json)
-        
+
     [<Fact>]
     let extractCorrect () =
         let json = JToken.Parse("""{"preferredTextSyncKind": 1}""")
-        Assert.Equal({preferredTextSyncKind = Some Config.Full}, InitOptions.ofJson json)
-        
+        Assert.Equal({ preferredTextSyncKind = Some Config.Full }, InitOptions.ofJson json)
+
         let json = JToken.Parse("""{"preferredTextSyncKind": 2}""")
-        Assert.Equal({preferredTextSyncKind = Some Config.Incremental}, InitOptions.ofJson json)
-        
+        Assert.Equal({ preferredTextSyncKind = Some Config.Incremental }, InitOptions.ofJson json)
+
     [<Fact>]
     let extractMalformed () =
         let json = JToken.Parse("""{"preferredTextSyncKind": 42}""")
-        Assert.Equal({preferredTextSyncKind = None}, InitOptions.ofJson json)
-        
-        let json = JToken.Parse("""{"preferredTextSyncKind": "full"}""")
-        Assert.Equal({preferredTextSyncKind = None}, InitOptions.ofJson json)
+        Assert.Equal({ preferredTextSyncKind = None }, InitOptions.ofJson json)
 
+        let json = JToken.Parse("""{"preferredTextSyncKind": "full"}""")
+        Assert.Equal({ preferredTextSyncKind = None }, InitOptions.ofJson json)

--- a/Tests/Tests.fsproj
+++ b/Tests/Tests.fsproj
@@ -8,34 +8,35 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <Compile Include="Helpers.fs"/>
-        <Compile Include="ParserTests.fs"/>
-        <Compile Include="TextTests.fs"/>
-        <Compile Include="MiscTests.fs"/>
-        <Compile Include="DiagTest.fs"/>
-        <Compile Include="ComplTests.fs"/>
-        <Compile Include="SematoTests.fs"/>
-        <Compile Include="WorkspaceTest.fs"/>
-        <Compile Include="TocTests.fs"/>
-        <Compile Include="RefsTests.fs"/>
-        <Compile Include="RefactorTests.fs"/>
-        <Compile Include="SymbolsTests.fs"/>
-        <Compile Include="ConfigTests.fs"/>
-        <Compile Include="GitIgnoreTest.fs"/>
-        <Compile Include="StateTests.fs"/>
-        <Compile Include="ServerTests.fs"/>
-        <Compile Include="Program.fs"/>
+        <Compile Include="Helpers.fs" />
+        <Compile Include="ParserTests.fs" />
+        <Compile Include="TextTests.fs" />
+        <Compile Include="MiscTests.fs" />
+        <Compile Include="DiagTest.fs" />
+        <Compile Include="ComplTests.fs" />
+        <Compile Include="SematoTests.fs" />
+        <Compile Include="WorkspaceTest.fs" />
+        <Compile Include="TocTests.fs" />
+        <Compile Include="RefsTests.fs" />
+        <Compile Include="RefactorTests.fs" />
+        <Compile Include="SymbolsTests.fs" />
+        <Compile Include="ConfigTests.fs" />
+        <Compile Include="GitIgnoreTest.fs" />
+        <Compile Include="StateTests.fs" />
+        <Compile Include="ServerTests.fs" />
+        <Compile Include="PathsTests.fs" />
+        <Compile Include="Program.fs" />
     </ItemGroup>
 
     <ItemGroup>
-        <EmbeddedResource Include="default.marksman.toml" LogicalName="default.marksman.toml"/>
+        <EmbeddedResource Include="default.marksman.toml" LogicalName="default.marksman.toml" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0"/>
-        <PackageReference Update="FSharp.Core" Version="6.0.5"/>
-        <PackageReference Include="Snapper" Version="2.3.2"/>
-        <PackageReference Include="xunit" Version="2.4.2"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+        <PackageReference Update="FSharp.Core" Version="6.0.5" />
+        <PackageReference Include="Snapper" Version="2.3.2" />
+        <PackageReference Include="xunit" Version="2.4.2" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
@@ -47,7 +48,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\Marksman\Marksman.fsproj"/>
+        <ProjectReference Include="..\Marksman\Marksman.fsproj" />
     </ItemGroup>
 
 </Project>

--- a/Tests/WorkspaceTest.fs
+++ b/Tests/WorkspaceTest.fs
@@ -5,6 +5,7 @@ open Ionide.LanguageServerProtocol.Types
 open Xunit
 
 open Marksman.Misc
+open Marksman.Paths
 open Marksman.Workspace
 open Marksman.Config
 

--- a/Tests/WorkspaceTest.fs
+++ b/Tests/WorkspaceTest.fs
@@ -54,7 +54,7 @@ module WorkspaceTest =
         let ws = Workspace.ofFolders None [ f1; f2 ]
 
         let f0Path = dummyRootPath [ "a" ] |> mkFolderId
-        let f0 = Folder.multiFile "f0" f0Path Map.empty None
+        let f0 = Folder.multiFile "f0" f0Path Seq.empty None
 
         let updWs = Workspace.withFolder f0 ws
 
@@ -68,7 +68,7 @@ module WorkspaceTest =
         let fPath = dummyRootPath [ "a" ] |> mkFolderId
 
         // Multi-file
-        let f = (Folder.multiFile "f0" fPath Map.empty fConfig)
+        let f = (Folder.multiFile "f0" fPath Seq.empty fConfig)
         let ws = Workspace.ofFolders None [ f ]
         let f = (Workspace.folders ws) |> Seq.head
         let updatedConfig = Folder.config f
@@ -88,7 +88,7 @@ module WorkspaceTest =
         let fPath = dummyRootPath [ "a" ] |> mkFolderId
 
         // Multi-file
-        let f = (Folder.multiFile "f0" fPath Map.empty None)
+        let f = (Folder.multiFile "f0" fPath Seq.empty None)
         let ws = Workspace.ofFolders wsConfig [ f ]
         let f = (Workspace.folders ws) |> Seq.head
         let updatedConfig = Folder.config f
@@ -109,7 +109,7 @@ module WorkspaceTest =
 
         // Multi-file
         let ws = Workspace.ofFolders wsConfig []
-        let f = (Folder.multiFile "f0" fPath Map.empty None)
+        let f = (Folder.multiFile "f0" fPath Seq.empty None)
         let ws = Workspace.withFolder f ws
         let f = (Workspace.folders ws) |> Seq.head
         let updatedConfig = Folder.config f

--- a/Tests/WorkspaceTest.fs
+++ b/Tests/WorkspaceTest.fs
@@ -23,10 +23,10 @@ module FolderTest =
 module DocTest =
     [<Fact>]
     let applyLspChange () =
-        let dummyPath = (dummyRootPath [ "dummy.md" ]) |> mkDocId (mkFolderId dummyRoot)
+        let dummyPath =
+            (dummyRootPath [ "dummy.md" ]) |> mkDocId (mkFolderId dummyRoot)
 
-        let empty =
-            Doc.mk dummyPath None (Text.mkText "")
+        let empty = Doc.mk dummyPath None (Text.mkText "")
 
         let insertChange =
             { TextDocument = { Uri = RootedRelPath.toSystem dummyPath.data; Version = Some 1 }
@@ -37,7 +37,7 @@ module DocTest =
 
         let updated = Doc.applyLspChange insertChange empty
         Assert.Equal("[", (Doc.text updated).content)
-        
+
     [<Fact(Skip = "Uri and # don't mix well")>]
     let pathFromRoot_SpecialChars () =
         let doc = FakeDoc.Mk(path = "blah#blah.md", contentLines = [||])


### PR DESCRIPTION
Overall, looks like a pretty good perf improvement, especially for larger workspaces. There's a lot of opportunities to further improve the perf/efficiency by doing things more incrementally.

## Benchmarks
**This is the baseline:**
```
BenchmarkDotNet=v0.13.5, OS=macOS Ventura 13.3.1 (22E261) [Darwin 22.4.0]
Apple M1 Pro, 1 CPU, 10 logical and 10 physical cores
.NET SDK=7.0.302
  [Host]     : .NET 7.0.5 (7.0.523.17405), Arm64 RyuJIT AdvSIMD DEBUG
  DefaultJob : .NET 7.0.5 (7.0.523.17405), Arm64 RyuJIT AdvSIMD
```

|       Method | FolderSize |             Mean |        Error |       StdDev |
|------------- |----------- |-----------------:|-------------:|-------------:|
|  gotoDefTime |         10 |         12.69 us |     0.021 us |     0.019 us |
| findRefsTime |         10 |      1,392.42 us |     2.681 us |     2.377 us |
|  gotoDefTime |         50 |         62.92 us |     0.078 us |     0.073 us |
| findRefsTime |         50 |    164,905.21 us |   229.081 us |   214.283 us |
|  gotoDefTime |        250 |        319.72 us |     0.575 us |     0.510 us |
| findRefsTime |        250 | 20,683,207.26 us | 6,810.020 us | 6,036.905 us |


Find refs has a really bad asymptotic – 20s per 250 fully-connected docs is way too long.

**After the fixes**:
Which gives a nice 180x (20s vs 115ms) improvement for the 250 docs benchmark.

|       Method | FolderSize |           Mean |       Error |      StdDev |
|------------- |----------- |---------------:|------------:|------------:|
|  gotoDefTime |         10 |       1.180 us |   0.0034 us |   0.0032 us |
| findRefsTime |         10 |     147.967 us |   0.7200 us |   0.6735 us |
|  gotoDefTime |         50 |       1.294 us |   0.0013 us |   0.0011 us |
| findRefsTime |         50 |   4,040.372 us |   4.7052 us |   4.4013 us |
|  gotoDefTime |        250 |       1.433 us |   0.0022 us |   0.0019 us |
| findRefsTime |        250 | 115,387.334 us | 118.0649 us | 104.6614 us |