### PR TITLE
core: Limit the # of completion candidates returned per request + mark response (in)complete when necessary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ install: publish
 else
 install: publish
 	mkdir -p $(PREFIX)/bin
-	install -Dm755 Marksman/bin/Release/net7.0/$(RID)/publish/marksman $(PREFIX)/bin
+	install -m755 Marksman/bin/Release/net7.0/$(RID)/publish/marksman $(PREFIX)/bin
 endif
 
 .PHONY: uninstall

--- a/Marksman/Server.fs
+++ b/Marksman/Server.fs
@@ -786,9 +786,17 @@ type MarksmanServer(client: MarksmanClient) =
                 monad' {
                     let! folder, doc = State.tryFindFolderAndDoc docUri state
 
-                    match Compl.findCandidatesInDoc folder doc pos with
+                    let maxCompletions = 50
+
+                    match
+                        Compl.findCandidatesInDoc folder doc pos
+                        |> Seq.truncate maxCompletions
+                        |> Array.ofSeq
+                    with
                     | [||] -> return! None
-                    | candidates -> { IsIncomplete = true; Items = candidates }
+                    | candidates ->
+                        let isIncomplete = Array.length candidates >= maxCompletions
+                        { IsIncomplete = isIncomplete; Items = candidates }
                 }
 
             LspResult.success candidates

--- a/Tests/ComplTests.fs
+++ b/Tests/ComplTests.fs
@@ -11,6 +11,7 @@ open Marksman.Misc
 
 let tryParsePartialElement text line col = PartialElement.inText text (Position.Mk(line, col))
 let parsePartialElement text line col = tryParsePartialElement text line col |> Option.get
+let findCandidatesInDoc folder doc pos = findCandidatesInDoc folder doc pos |> Array.ofSeq
 
 [<StoreSnapshotsPerClass>]
 module PartialElementWiki =


### PR DESCRIPTION
Now the server returns at most 50 candidates. The response is marked as incomplete when the # is exactly 50, otherwise it's marked complete and the client doesn't need to issue any additional requests.