### PR TITLE
Add a code action to create nonexistent linked files

### DIFF
--- a/LanguageServerProtocol/Types.fs
+++ b/LanguageServerProtocol/Types.fs
@@ -275,6 +275,11 @@ type DocumentChange =
   | RenameFile of RenameFile
   | DeleteFile of DeleteFile
 
+module DocumentChange =
+    let createFile uri = DocumentChange.CreateFile {Kind = "create"; Uri = uri}
+    let renameFile oldUri newUri = DocumentChange.RenameFile {Kind = "rename"; oldUri = oldUri; newUri = newUri}
+    let deleteFile uri = DocumentChange.DeleteFile {Kind = "delete"; Uri = uri}
+
 type TraceSetting =
   | Off = 0
   | Messages = 1

--- a/LanguageServerProtocol/Types.fs
+++ b/LanguageServerProtocol/Types.fs
@@ -236,6 +236,45 @@ type TextDocumentEdit =
     /// The edits to be applied.
     Edits: TextEdit [] }
 
+/// Create file operation
+type CreateFile =
+  { /// The kind of resource operation. This should always be `"create"`.
+    Kind: string
+
+    /// The resource to create.
+    Uri: DocumentUri
+  }
+
+/// Rename file operation
+type RenameFile =
+  { /// The kind of resource operation. This should always be `"rename"`.
+    Kind: string
+
+    /// The old (existing) location.
+    oldUri: DocumentUri
+
+    /// The new location.
+    newUri: DocumentUri
+  }
+
+/// Delete file operation
+type DeleteFile =
+  { /// The kind of resource operation. This should always be `"delete"`.
+    Kind: string
+
+    /// The file to delete.
+    Uri: DocumentUri
+  }
+
+
+/// Represents the possible values in the `WorkspaceEdit`'s `DocumentChanges` field.
+[<ErasedUnion>]
+type DocumentChange =
+  | TextDocumentEdit of TextDocumentEdit
+  | CreateFile of CreateFile
+  | RenameFile of RenameFile
+  | DeleteFile of DeleteFile
+
 type TraceSetting =
   | Off = 0
   | Messages = 1
@@ -1147,10 +1186,13 @@ type WorkspaceEdit =
     /// where each text document edit addresses a specific version of a text document.
     /// Whether a client supports versioned document edits is expressed via
     /// `WorkspaceClientCapabilities.workspaceEdit.documentChanges`.
-    DocumentChanges: TextDocumentEdit [] option }
-  static member DocumentChangesToChanges(edits: TextDocumentEdit []) =
+    DocumentChanges: DocumentChange [] option }
+  static member DocumentChangesToChanges(edits: DocumentChange []) =
     edits
-    |> Array.map (fun edit -> edit.TextDocument.Uri.ToString(), edit.Edits)
+    |> Array.collect (fun docChange ->
+                       match docChange with
+                       | TextDocumentEdit edit -> [|edit.TextDocument.Uri.ToString(), edit.Edits|]
+                       | _ -> [||])
     |> Map.ofArray
 
   static member CanUseDocumentChanges(capabilities: ClientCapabilities) =
@@ -1158,11 +1200,11 @@ type WorkspaceEdit =
      |> Option.bind (fun x -> x.WorkspaceEdit)
      |> Option.bind (fun x -> x.DocumentChanges)) = Some true
 
-  static member Create(edits: TextDocumentEdit [], capabilities: ClientCapabilities) =
+  static member Create(documentChanges: DocumentChange [], capabilities: ClientCapabilities) =
     if WorkspaceEdit.CanUseDocumentChanges(capabilities) then
-      { Changes = None; DocumentChanges = Some edits }
+      { Changes = None; DocumentChanges = Some documentChanges }
     else
-      { Changes = Some(WorkspaceEdit.DocumentChangesToChanges edits)
+      { Changes = Some(WorkspaceEdit.DocumentChangesToChanges documentChanges)
         DocumentChanges = None }
 
 type MessageType =

--- a/Marksman/Config.fs
+++ b/Marksman/Config.fs
@@ -124,21 +124,21 @@ module TextSync =
 /// without lenses manageable.
 type Config =
     { caTocEnable: option<bool>
-      caCreateNonexistentLinkEnable: option<bool>
+      caCreateMissingFileEnable: option<bool>
       coreMarkdownFileExtensions: option<array<string>>
       coreTextSync: option<TextSync>
       complWikiStyle: option<ComplWikiStyle> }
 
     static member Default =
         { caTocEnable = Some true
-          caCreateNonexistentLinkEnable = Some true
+          caCreateMissingFileEnable = Some true
           coreMarkdownFileExtensions = Some [| "md"; "markdown" |]
           coreTextSync = Some Full
           complWikiStyle = Some TitleSlug }
 
     static member Empty =
         { caTocEnable = None
-          caCreateNonexistentLinkEnable = None
+          caCreateMissingFileEnable = None
           coreMarkdownFileExtensions = None
           coreTextSync = None
           complWikiStyle = None }
@@ -148,9 +148,9 @@ type Config =
         |> Option.orElse Config.Default.caTocEnable
         |> Option.get
 
-    member this.CaCreateNonexistentLinkEnable() =
-        this.caCreateNonexistentLinkEnable
-        |> Option.orElse Config.Default.caCreateNonexistentLinkEnable
+    member this.CaCreateMissingFileEnable() =
+        this.caCreateMissingFileEnable
+        |> Option.orElse Config.Default.caCreateMissingFileEnable
         |> Option.get
 
     member this.CoreMarkdownFileExtensions() =
@@ -172,8 +172,8 @@ let private configOfTable (table: TomlTable) : LookupResult<Config> =
     monad {
         let! caTocEnable = getFromTableOpt<bool> table [] [ "code_action"; "toc"; "enable" ]
 
-        let! caCreateNonexistentLinkEnable =
-            getFromTableOpt<bool> table [] [ "code_action"; "create_nonexistent_link"; "enable" ]
+        let! caCreateMissingFileEnable =
+            getFromTableOpt<bool> table [] [ "code_action"; "create_missing_file"; "enable" ]
 
         let! coreMarkdownFileExtensions =
             getFromTableOpt<array<string>> table [] [ "core"; "markdown"; "file_extensions" ]
@@ -187,7 +187,7 @@ let private configOfTable (table: TomlTable) : LookupResult<Config> =
             complWikiStyle |> Option.bind ComplWikiStyle.ofStringOpt
 
         { caTocEnable = caTocEnable
-          caCreateNonexistentLinkEnable = caCreateNonexistentLinkEnable
+          caCreateMissingFileEnable = caCreateMissingFileEnable
           coreMarkdownFileExtensions = coreMarkdownFileExtensions
           coreTextSync = coreTextSync
           complWikiStyle = complWikiStyle }
@@ -198,9 +198,9 @@ module Config =
 
     let merge hi low =
         { caTocEnable = hi.caTocEnable |> Option.orElse low.caTocEnable
-          caCreateNonexistentLinkEnable =
-            hi.caCreateNonexistentLinkEnable
-            |> Option.orElse low.caCreateNonexistentLinkEnable
+          caCreateMissingFileEnable =
+            hi.caCreateMissingFileEnable
+            |> Option.orElse low.caCreateMissingFileEnable
           coreMarkdownFileExtensions =
             hi.coreMarkdownFileExtensions
             |> Option.orElse low.coreMarkdownFileExtensions

--- a/Marksman/Config.fs
+++ b/Marksman/Config.fs
@@ -124,18 +124,21 @@ module TextSync =
 /// without lenses manageable.
 type Config =
     { caTocEnable: option<bool>
+      caCreateNonexistentLinkEnable: option<bool>
       coreMarkdownFileExtensions: option<array<string>>
       coreTextSync: option<TextSync>
       complWikiStyle: option<ComplWikiStyle> }
 
     static member Default =
         { caTocEnable = Some true
+          caCreateNonexistentLinkEnable = Some true
           coreMarkdownFileExtensions = Some [| "md"; "markdown" |]
           coreTextSync = Some Full
           complWikiStyle = Some TitleSlug }
 
     static member Empty =
         { caTocEnable = None
+          caCreateNonexistentLinkEnable = None
           coreMarkdownFileExtensions = None
           coreTextSync = None
           complWikiStyle = None }
@@ -143,6 +146,11 @@ type Config =
     member this.CaTocEnable() =
         this.caTocEnable
         |> Option.orElse Config.Default.caTocEnable
+        |> Option.get
+
+    member this.CaCreateNonexistentLinkEnable() =
+        this.caCreateNonexistentLinkEnable
+        |> Option.orElse Config.Default.caCreateNonexistentLinkEnable
         |> Option.get
 
     member this.CoreMarkdownFileExtensions() =
@@ -164,6 +172,9 @@ let private configOfTable (table: TomlTable) : LookupResult<Config> =
     monad {
         let! caTocEnable = getFromTableOpt<bool> table [] [ "code_action"; "toc"; "enable" ]
 
+        let! caCreateNonexistentLinkEnable =
+            getFromTableOpt<bool> table [] [ "code_action"; "create_nonexistent_link"; "enable" ]
+
         let! coreMarkdownFileExtensions =
             getFromTableOpt<array<string>> table [] [ "core"; "markdown"; "file_extensions" ]
 
@@ -176,6 +187,7 @@ let private configOfTable (table: TomlTable) : LookupResult<Config> =
             complWikiStyle |> Option.bind ComplWikiStyle.ofStringOpt
 
         { caTocEnable = caTocEnable
+          caCreateNonexistentLinkEnable = caCreateNonexistentLinkEnable
           coreMarkdownFileExtensions = coreMarkdownFileExtensions
           coreTextSync = coreTextSync
           complWikiStyle = complWikiStyle }
@@ -186,6 +198,9 @@ module Config =
 
     let merge hi low =
         { caTocEnable = hi.caTocEnable |> Option.orElse low.caTocEnable
+          caCreateNonexistentLinkEnable =
+            hi.caCreateNonexistentLinkEnable
+            |> Option.orElse low.caCreateNonexistentLinkEnable
           coreMarkdownFileExtensions =
             hi.coreMarkdownFileExtensions
             |> Option.orElse low.coreMarkdownFileExtensions

--- a/Marksman/Misc.fs
+++ b/Marksman/Misc.fs
@@ -153,6 +153,13 @@ let chopMarkdownExt (configuredExts: seq<string>) (path: string) : string =
     else
         path
 
+let ensureMarkdownExt (configuredExts: seq<string>) (path: string) : string =
+    if isMarkdownFile configuredExts path then
+        path
+    else
+        let ext = Seq.head configuredExts
+        $"{path}.{ext}"
+
 let isPotentiallyMarkdownFile (configuredExts: seq<string>) (path: string) : bool =
     let ext = Path.GetExtension path
 

--- a/Marksman/Refactor.fs
+++ b/Marksman/Refactor.fs
@@ -48,9 +48,7 @@ let mkWorkspaceEdit
     for docEdit in docEdits do
         docEdit.Edits |> Array.sortInPlaceWith (fun x y -> -(compare x y))
 
-    let docChanges =
-      docEdits
-      |> Array.map (DocumentChange.TextDocumentEdit)
+    let docChanges = docEdits |> Array.map (DocumentChange.TextDocumentEdit)
 
     if supportsDocumentEdit then
         { Changes = None; DocumentChanges = Some docChanges }

--- a/Marksman/Refactor.fs
+++ b/Marksman/Refactor.fs
@@ -48,10 +48,14 @@ let mkWorkspaceEdit
     for docEdit in docEdits do
         docEdit.Edits |> Array.sortInPlaceWith (fun x y -> -(compare x y))
 
+    let docChanges =
+      docEdits
+      |> Array.map (DocumentChange.TextDocumentEdit)
+
     if supportsDocumentEdit then
-        { Changes = None; DocumentChanges = Some docEdits }
+        { Changes = None; DocumentChanges = Some docChanges }
     else
-        { Changes = Some(WorkspaceEdit.DocumentChangesToChanges docEdits)
+        { Changes = Some(WorkspaceEdit.DocumentChangesToChanges docChanges)
           DocumentChanges = None }
 
 let renameMarkdownLabel (newLabel: string) (element: Element) : option<TextEdit> =

--- a/Marksman/Server.fs
+++ b/Marksman/Server.fs
@@ -922,9 +922,9 @@ type MarksmanServer(client: MarksmanClient) =
         <| fun state ->
             let docPath = opts.TextDocument.Uri |> UriWith.mkAbs
 
-            let codeAction title edit =
+            let codeAction title kind edit =
                 { Title = title
-                  Kind = Some CodeActionKind.Source
+                  Kind = kind
                   Diagnostics = None
                   Command = None
                   Data = None
@@ -945,24 +945,25 @@ type MarksmanServer(client: MarksmanClient) =
                             let wsEdit =
                                 (CodeActions.documentEdit ca.edit ca.newText opts.TextDocument.Uri)
 
-                            codeAction ca.name wsEdit)
+                            let caKind = Some CodeActionKind.Source
+
+                            codeAction ca.name caKind wsEdit)
                     else
                         [||]
 
-                let createLinkAction =
-                    if config.CaCreateNonexistentLinkEnable() then
-                        CodeActions.createNonexistentLink opts.Range opts.Context doc folder
+                let createMissingFileAction =
+                    if config.CaCreateMissingFileEnable() then
+                        CodeActions.createMissingFile opts.Range opts.Context doc folder
                         |> Option.toArray
                         |> Array.map (fun ca ->
                             let wsEdit = CodeActions.createFile ca.newFileUri
-                            codeAction ca.name wsEdit)
+                            let caKind = Some CodeActionKind.QuickFix
+                            codeAction ca.name caKind wsEdit)
                     else
                         [||]
 
                 let codeActions: TextDocumentCodeActionResult =
-                    seq { tocAction
-                          createLinkAction }
-                    |> Array.concat
+                    Array.concat [| tocAction; createMissingFileAction |]
                     |> Array.map U2.Second
 
                 Mutation.output (LspResult.success (Some codeActions))

--- a/Marksman/Server.fs
+++ b/Marksman/Server.fs
@@ -949,8 +949,21 @@ type MarksmanServer(client: MarksmanClient) =
                     else
                         [||]
 
+                let createLinkAction =
+                    if config.CaCreateNonexistentLinkEnable() then
+                        CodeActions.createNonexistentLink opts.Range opts.Context doc folder
+                        |> Option.toArray
+                        |> Array.map (fun ca ->
+                            let wsEdit = CodeActions.createFile ca.newFileUri
+                            codeAction ca.name wsEdit)
+                    else
+                        [||]
+
                 let codeActions: TextDocumentCodeActionResult =
-                    tocAction |> Array.map U2.Second
+                    seq { tocAction
+                          createLinkAction }
+                    |> Array.concat
+                    |> Array.map U2.Second
 
                 Mutation.output (LspResult.success (Some codeActions))
 

--- a/Tests/RefactorTests.fs
+++ b/Tests/RefactorTests.fs
@@ -16,6 +16,7 @@ let editRanges =
                     match docChange with
                     | TextDocumentEdit docEdit -> docEdit
                     | _ -> failwith $"Refactoring should always produce TextDocumentEdits"
+
                 let doc = Path.GetFileName(docEdit.TextDocument.Uri)
                 let ranges = docEdit.Edits |> Array.map (fun x -> x.Range)
                 doc, ranges)

--- a/Tests/RefactorTests.fs
+++ b/Tests/RefactorTests.fs
@@ -9,9 +9,13 @@ let editRanges =
     function
     | Refactor.Edit wsEdit ->
         match wsEdit.DocumentChanges with
-        | Some docEdits ->
-            docEdits
-            |> Array.map (fun docEdit ->
+        | Some docChanges ->
+            docChanges
+            |> Array.map (fun docChange ->
+                let docEdit =
+                    match docChange with
+                    | TextDocumentEdit docEdit -> docEdit
+                    | _ -> failwith $"Refactoring should always produce TextDocumentEdits"
                 let doc = Path.GetFileName(docEdit.TextDocument.Uri)
                 let ranges = docEdit.Edits |> Array.map (fun x -> x.Range)
                 doc, ranges)

--- a/Tests/default.marksman.toml
+++ b/Tests/default.marksman.toml
@@ -7,7 +7,11 @@ markdown.file_extensions = ["md", "markdown"]
 text_sync = "full"
 
 [code_action]
-toc.enable = true # Enable/disable "Table of Contents" code action
+# Enable/disable "Table of Contents" code action
+toc.enable = true
+
+# Enable/disable "Create nonexistent linked file" code action
+create_nonexistent_link.enable = true
 
 [completion]
 # The style of wiki links completion.

--- a/Tests/default.marksman.toml
+++ b/Tests/default.marksman.toml
@@ -10,8 +10,8 @@ text_sync = "full"
 # Enable/disable "Table of Contents" code action
 toc.enable = true
 
-# Enable/disable "Create nonexistent linked file" code action
-create_nonexistent_link.enable = true
+# Enable/disable "Create missing linked file" code action
+create_missing_file.enable = true
 
 [completion]
 # The style of wiki links completion.


### PR DESCRIPTION
Here's my first pass at a new code action to create files which are linked, but don't exist in the workspace (i.e. a goto-def on the link would error). Choosing the code action creates the file in the root of the workspace folder.

Closes #219.

A few notes:

- I modified `LanguageServerProtocol/Types.fs` to support the create file operation (and other file resource changes). I added a new type for each type of resource operation, and added them all to a new `[<ErasedUnion>]` sum type `DocumentChange`. This type then replaced `TextDocumentEdit` where appropriate. I'm not 100% sure that this is the best way to go about this, but it works and is fairly neat.
- A particular wart in the above is that each of these new types has the field `Kind: string`; I would rather use the existing type `ResourceOperationKind`, but I couldn't figure out how to get those to be serialised into JSON in lowercase (i.e. they would become `"Create"` instead of `"create"`). Any pointers on how to make this happen using `ResourceOperationKind` would be awesome; in particular, I tried using JSON.NET's [`JsonPropertyAttribute`](https://www.newtonsoft.com/json/help/html/T_Newtonsoft_Json_JsonPropertyAttribute.htm) and [`NamingStrategy`](https://www.newtonsoft.com/json/help/html/T_Newtonsoft_Json_Serialization_NamingStrategy.htm) with no change in the output.
- `createNonexistentLink` in `CodeActions.fs` is the function which carries out the main logic for this action. I've used the `Start` of the `range` parameter given to the code action as the position which checks for a link; I'm not sure if this should use the start, or the end of the range, or something else? I'm also happy to take any style feedback, especially as I'm pretty fresh to F#.
- To support this I added a function `ensureMarkdownExt` to `Misc.fs` which ensures that a path has a configured Markdown extension, or adds the first configured extension if there is none. This is similar to `chopMarkdownExt`. 
- I also added this code action to the handler in `Server.fs`; keen for style advice here as well.
- The rest of the changes are adding this code action as a configurable option, which is pretty boilerplatey. The only thought I had was whether it would be useful to allow configuring where the created file is located (e.g. in a subdirectory)? Currently all files created with this action are just dumped in the workspace folder, which works for my use case, but might not for others.

The major problem that I still have with this implementation is that once the file is created, Marksman doesn't notice that fact straight away. In particular, if I try to goto-def on the link to the just-created file, it still gives an error. If I manually open the file (using Neovim's `e` command in my case), _then_ the link works with goto-def. I think the workspace state isn't being updated when we do this code action; I would have thought that this might be triggered by the client when it creates the file upon receiving the `CreateFile` request, but it seems not. It's possible that this could be a bug in Neovim, that it's not sending [`DidCreateFiles` notifications](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_didCreateFiles), but I don't have any other client configured at the moment to be able to test for that. If you have any knowledge of what might be the path forward, that would be super helpful.