### PR TITLE
feat: Basic support for nested tags

### DIFF
--- a/Marksman/Parser.fs
+++ b/Marksman/Parser.fs
@@ -53,7 +53,7 @@ module Markdown =
             else
                 let start = slice.Start
                 let offsetStart = processor.GetSourcePosition(slice.Start)
-                let shouldAccept (c: char) = c.IsAlphaNumeric() || c = '-' || c = '_'
+                let shouldAccept (c: char) = c.IsAlphaNumeric() || c = '-' || c = '_' || c = '/'
 
                 while (shouldAccept (slice.PeekChar())) do
                     slice.NextChar() |> ignore

--- a/Tests/ParserTests.fs
+++ b/Tests/ParserTests.fs
@@ -374,6 +374,16 @@ module TagsTests =
             [ "T: name=tag1; range=(0,1)-(0,5) @ (0,0)-(0,5)"
               "T: name=tag2; range=(0,7)-(0,11) @ (0,6)-(0,11)" ]
 
+    [<Fact>]
+    let tags_nested () =
+        let text = "#tag1/subtag1,#tag2/subtag2/subsubtag2"
+        let cst = scrapeString text
+
+        checkInlineSnapshot
+            cst
+            [ "T: name=tag1/subtag1; range=(0,1)-(0,13) @ (0,0)-(0,13)"
+              "T: name=tag2/subtag2/subsubtag2; range=(0,15)-(0,38) @ (0,14)-(0,38)" ]
+
 module DocUrlTests =
     let mkUrlNode str =
         Node.mk str (Range.Mk(0, 0, 0, str.Length)) (UrlEncoded.mkUnchecked str)


### PR DESCRIPTION
fixes #267 

As described in the issue this only solves the basic requirements so that nested tags (like in Obsidian) work correctly in terms of references, symbols and auto completion.