### PR TITLE
feat: Add code lenses with '# of references' (server side)

### DIFF
--- a/Marksman/Doc.fs
+++ b/Marksman/Doc.fs
@@ -31,6 +31,8 @@ type Doc =
 
     member this.Structure = this.structure
 
+    member this.Index = this.index
+
     interface IEquatable<Doc> with
         member this.Equals(other) = this.id = other.id && this.text = other.text
 

--- a/Marksman/Doc.fsi
+++ b/Marksman/Doc.fsi
@@ -17,6 +17,7 @@ type Doc =
     member RootPath: RootPath
     member RelPath: RelPath
     member Structure: Structure
+    member Index: Index
 
     interface System.IComparable
     interface System.IComparable<Doc>

--- a/Marksman/Lenses.fs
+++ b/Marksman/Lenses.fs
@@ -12,9 +12,10 @@ let private humanRefCount cnt = if cnt = 1 then "1 reference" else $"{cnt} refer
 
 let forDoc (folder: Folder) (doc: Doc) =
     seq {
+        // Process headers
         for h in doc.Index.headings do
-            let refs = Dest.findElementRefs false folder doc (Cst.H h)
-            let refCount = Seq.length refs
+            let refCount =
+                Dest.findElementRefs false folder doc (Cst.H h) |> Seq.length
 
             if refCount > 0 then
                 let command =
@@ -23,5 +24,18 @@ let forDoc (folder: Folder) (doc: Doc) =
                       Arguments = None }
 
                 yield { Range = h.range; Command = Some command; Data = None }
+
+        // Process link defs
+        for ld in doc.Index.linkDefs do
+            let refCount =
+                Dest.findElementRefs false folder doc (Cst.MLD ld) |> Seq.length
+
+            if refCount > 0 then
+                let command =
+                    { Title = humanRefCount refCount
+                      Command = findReferencesLens
+                      Arguments = None }
+
+                yield { Range = ld.range; Command = Some command; Data = None }
     }
     |> Array.ofSeq

--- a/Marksman/Lenses.fs
+++ b/Marksman/Lenses.fs
@@ -1,0 +1,27 @@
+module Marksman.Lenses
+
+open Ionide.LanguageServerProtocol.Types
+
+open Marksman.Doc
+open Marksman.Folder
+open Marksman.Refs
+
+let findReferencesLens = "marksman.findReferences"
+
+let private humanRefCount cnt = if cnt = 1 then "1 reference" else $"{cnt} references"
+
+let forDoc (folder: Folder) (doc: Doc) =
+    seq {
+        for h in doc.Index.headings do
+            let refs = Dest.findElementRefs false folder doc (Cst.H h)
+            let refCount = Seq.length refs
+
+            if refCount > 0 then
+                let command =
+                    { Title = humanRefCount refCount
+                      Command = findReferencesLens
+                      Arguments = None }
+
+                yield { Range = h.range; Command = Some command; Data = None }
+    }
+    |> Array.ofSeq

--- a/Marksman/Marksman.fsproj
+++ b/Marksman/Marksman.fsproj
@@ -60,6 +60,7 @@
         <Compile Include="Compl.fs"/>
         <Compile Include="Refactor.fs"/>
         <Compile Include="Symbols.fs"/>
+        <Compile Include="Lenses.fs"/>
         <Compile Include="Server.fs"/>
         <Compile Include="Program.fs"/>
     </ItemGroup>

--- a/Marksman/Server.fs
+++ b/Marksman/Server.fs
@@ -190,7 +190,7 @@ module ServerUtil =
                       Full = { Delta = Some false } |> U2.Second |> Some }
             RenameProvider = renameOptions
             CodeLensProvider = Some { ResolveProvider = None }
-            ExecuteCommandProvider = Some { commands = None } }
+            ExecuteCommandProvider = Some { commands = Some [||] } }
 
 type MarksmanStatusParams = { state: string; docCount: int }
 

--- a/Tests/LensesTests.fs
+++ b/Tests/LensesTests.fs
@@ -1,0 +1,29 @@
+module Marksman.LensesTests
+
+open Xunit
+
+open Marksman.Helpers
+
+let d1 =
+    FakeDoc.Mk(path = "d1.md", contentLines = [| "# Doc 1"; "## Sub"; "[[#Sub]]"; "## No ref" |])
+
+let d2 =
+    FakeDoc.Mk(path = "d2.md", contentLines = [| "# Doc 2"; "[[Doc 1#Sub]]" |])
+
+let f = FakeFolder.Mk([ d1; d2 ])
+
+[<Fact>]
+let basicLenses () =
+    let lenses =
+        Lenses.forDoc f d1
+        |> Array.map (fun lens -> $"{lens.Command.Value}, {lens.Range}")
+
+    checkInlineSnapshot
+        id
+        lenses
+        [ "{ Title = \"1 reference\""
+          "  Command = \"marksman.findReferences\""
+          "  Arguments = None }, (0,0)-(0,7)"
+          "{ Title = \"2 references\""
+          "  Command = \"marksman.findReferences\""
+          "  Arguments = None }, (1,0)-(1,6)" ]

--- a/Tests/LensesTests.fs
+++ b/Tests/LensesTests.fs
@@ -4,16 +4,19 @@ open Xunit
 
 open Marksman.Helpers
 
-let d1 =
-    FakeDoc.Mk(path = "d1.md", contentLines = [| "# Doc 1"; "## Sub"; "[[#Sub]]"; "## No ref" |])
-
-let d2 =
-    FakeDoc.Mk(path = "d2.md", contentLines = [| "# Doc 2"; "[[Doc 1#Sub]]" |])
-
-let f = FakeFolder.Mk([ d1; d2 ])
-
 [<Fact>]
-let basicLenses () =
+let basicHeaderLenses () =
+    let d1 =
+        FakeDoc.Mk(
+            path = "d1.md",
+            contentLines = [| "# Doc 1"; "## Sub"; "[[#Sub]]"; "## No ref" |]
+        )
+
+    let d2 =
+        FakeDoc.Mk(path = "d2.md", contentLines = [| "# Doc 2"; "[[Doc 1#Sub]]" |])
+
+    let f = FakeFolder.Mk([ d1; d2 ])
+
     let lenses =
         Lenses.forDoc f d1
         |> Array.map (fun lens -> $"{lens.Command.Value}, {lens.Range}")
@@ -27,3 +30,24 @@ let basicLenses () =
           "{ Title = \"2 references\""
           "  Command = \"marksman.findReferences\""
           "  Arguments = None }, (1,0)-(1,6)" ]
+
+[<Fact>]
+let basicLinkDefLenses () =
+    let d1 =
+        FakeDoc.Mk(
+            path = "d1.md",
+            contentLines = [| "[foo]"; "[foo][]"; "[bar]"; ""; "[foo]: /url" |]
+        )
+
+    let f = FakeFolder.Mk([ d1 ])
+
+    let lenses =
+        Lenses.forDoc f d1
+        |> Array.map (fun lens -> $"{lens.Command.Value}, {lens.Range}")
+
+    checkInlineSnapshot
+        id
+        lenses
+        [ "{ Title = \"2 references\""
+          "  Command = \"marksman.findReferences\""
+          "  Arguments = None }, (4,0)-(4,11)" ]

--- a/Tests/Tests.fsproj
+++ b/Tests/Tests.fsproj
@@ -29,6 +29,7 @@
         <Compile Include="AstTests.fs" />
         <Compile Include="ConnTest.fs" />
         <Compile Include="MMapTests.fs" />
+        <Compile Include="LensesTests.fs" />
         <Compile Include="Program.fs" />
     </ItemGroup>
 


### PR DESCRIPTION
This just provides a lens with something like '4 references' next to a header.
Clicking on the lens won't actually do anything yet because command handling needs to be implemented by every client.

This (partially) addresses #28 

NOTE: after #269 references are resolved *incrementally* based on document symbols rather than CSTs; which makes 'find references' requests practically free and lenses very cheap. Before #269 a code lens with references would be very expensive.

TODO:
* [x] references for headers
* [x] references for link defs
