### PR TITLE
fix: InternName.tryAsPath shouldn't crash on `/` root path link

### DIFF
--- a/Marksman/Names.fs
+++ b/Marksman/Names.fs
@@ -110,14 +110,16 @@ module InternName =
         if Uri.IsWellFormedUriString(name, UriKind.Absolute) then
             None
         else if name.StartsWith('/') then
-            let relPath =
-                LocalPath.ofSystem (
+            let relPathOpt =
+                LocalPath.tryOfSystem (
                     UrlEncoded.mkUnchecked (name.TrimStart('/')) |> UrlEncoded.decode
                 )
 
-            let rootPath = RootedRelPath.rootPath src.Path
-            let namePath = RootedRelPath.mk rootPath relPath
-            Some(ExactAbs namePath)
+            relPathOpt
+            |> Option.map (fun relPath ->
+                let rootPath = RootedRelPath.rootPath src.Path
+                let namePath = RootedRelPath.mk rootPath relPath
+                ExactAbs namePath)
         else
             try
                 let rawNamePath =

--- a/Tests/RefsTests.fs
+++ b/Tests/RefsTests.fs
@@ -570,3 +570,11 @@ module EncodingTests =
 
         let refs = resolveAtPos doc1 14 5
         checkInlineSnapshot (fun x -> x.ToString()) refs [ "doc.3.with.dots" ]
+
+module RegressionTests =
+    [<Fact>]
+    let rootLink_issue275 () =
+        let doc = FakeDoc.Mk(path = "doc.md", contentLines = [| "[](/)" |])
+        let folder = FakeFolder.Mk([ doc ])
+        let el = requireElementAtPos doc 0 4
+        Assert.Empty(Dest.tryResolveElement folder doc el)


### PR DESCRIPTION
Fixes #275 