### PR TITLE
deps: Bump versions

### DIFF
--- a/Benchmarks/Benchmarks.fsproj
+++ b/Benchmarks/Benchmarks.fsproj
@@ -10,7 +10,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="BenchmarkDotNet" Version="0.13.5" />
+      <PackageReference Include="BenchmarkDotNet" Version="0.13.11" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Marksman/Marksman.fsproj
+++ b/Marksman/Marksman.fsproj
@@ -66,13 +66,13 @@
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="FSharp.SystemCommandLine" Version="0.13.0-beta4"/>
-        <PackageReference Include="FSharpPlus" Version="1.2.4"/>
+        <PackageReference Include="FSharpPlus" Version="1.5.0"/>
         <PackageReference Include="Glob" Version="1.1.9"/>
         <PackageReference Include="Markdig" Version="0.33.0"/>
         <!--        <PackageReference Include="Ionide.LanguageServerProtocol" Version="0.3.1" />-->
         <PackageReference Include="Serilog" Version="2.11.0"/>
         <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1"/>
-        <PackageReference Include="Tomlyn" Version="0.16.0"/>
+        <PackageReference Include="Tomlyn" Version="0.17.0"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\LanguageServerProtocol\LanguageServerProtocol.fsproj"/>

--- a/Tests/Tests.fsproj
+++ b/Tests/Tests.fsproj
@@ -38,14 +38,14 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
-        <PackageReference Include="Snapper" Version="2.3.2" />
-        <PackageReference Include="xunit" Version="2.4.2" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+        <PackageReference Include="Snapper" Version="2.4.0" />
+        <PackageReference Include="xunit" Version="2.6.2" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.1.2">
+        <PackageReference Include="coverlet.collector" Version="6.0.0">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>


### PR DESCRIPTION
Serilog can't be upgraded because LSP lib needs v2
