### PR TITLE
feat: support escape slash in wikilinks

### DIFF
--- a/Marksman/Misc.fs
+++ b/Marksman/Misc.fs
@@ -75,7 +75,7 @@ type String with
         sb.ToString()
 
     member this.EncodeForWiki() : string =
-        let replacement = [| "#", "%23"; "[", "%5B"; "]", "%5D"; "|", "%7C" |]
+        let replacement = [| "#", "%23"; "[", "%5B"; "]", "%5D"; "|", "%7C"; "\\|", "%7C" |]
 
         replacement
         |> Array.fold (fun (sb: StringBuilder) -> sb.Replace) (StringBuilder(this))

--- a/Tests/MiscTests.fs
+++ b/Tests/MiscTests.fs
@@ -93,8 +93,8 @@ module StringExtensionsTests =
 
     [<Fact>]
     let encodeForWiki_2 () =
-        let original = "blah #blah [] () |"
-        let expected = "blah %23blah %5B%5D () %7C"
+        let original = "blah #blah [] () | \\|"
+        let expected = "blah %23blah %5B%5D () %7C %7C"
         let actual = original.EncodeForWiki()
         Assert.Equal(expected, actual)
         Assert.Equal(original, actual.UrlDecode())


### PR DESCRIPTION
Ref: https://github.com/artempyanykh/marksman/issues/288

The pipe operator used in WikiLinks can now be escaped with a backwards slash `\`.