### PR TITLE
feat: Add configuration option for setting number of completion candidates

### DIFF
--- a/Marksman/Server.fs
+++ b/Marksman/Server.fs
@@ -793,7 +793,7 @@ type MarksmanServer(client: MarksmanClient) =
                 monad' {
                     let! folder, doc = State.tryFindFolderAndDoc docUri state
 
-                    let maxCompletions = 50
+                    let maxCompletions = (Folder.configOrDefault folder).ComplCandidates()
 
                     match
                         Compl.findCandidatesInDoc folder doc pos

--- a/Tests/ConfigTests.fs
+++ b/Tests/ConfigTests.fs
@@ -101,6 +101,20 @@ paranoid = true
     Assert.Equal(Some expected, actual)
 
 [<Fact>]
+let testParse_7 () =
+    let content =
+        """
+[completion]
+candidates = 100
+"""
+
+    let actual = Config.tryParse content
+
+    let expected = { Config.Empty with complCandidates = Some 100 }
+
+    Assert.Equal(Some expected, actual)
+
+[<Fact>]
 let testParse_broken_0 () =
     let content =
         """
@@ -138,6 +152,28 @@ let testParse_broken_3 () =
         """
 [core]
 markdown.file_extensions = [["md"], ["markdown"]]
+"""
+
+    let actual = Config.tryParse content
+    Assert.Equal(None, actual)
+
+[<Fact>]
+let testParse_broken_4 () =
+    let content =
+        """
+[completion]
+candidates = "fifty"
+"""
+
+    let actual = Config.tryParse content
+    Assert.Equal(None, actual)
+
+[<Fact>]
+let testParse_broken_5 () =
+    let content =
+        """
+[completion]
+candidates = -1
 """
 
     let actual = Config.tryParse content

--- a/Tests/default.marksman.toml
+++ b/Tests/default.marksman.toml
@@ -32,6 +32,8 @@ toc.enable = true
 create_missing_file.enable = true
 
 [completion]
+# The maximum number of candidates returned for a completion 
+candidates = 50
 # The style of wiki links completion.
 # Other values include: 
 # * "file-stem" to complete using file name without an extension,


### PR DESCRIPTION
After a conversation about adding support for configuring the number of completion candidates in https://github.com/artempyanykh/marksman/issues/315, I decided to try implementing it.

It is still work in progress, and I'll update the status once it works, and the tests pass.