### PR TITLE
fix: Do not suggest 'Create file' code action for broken heading references

### DIFF
--- a/Marksman/Refs.fs
+++ b/Marksman/Refs.fs
@@ -161,7 +161,7 @@ module Dest =
         | Some(IntraRef(IntraSection _)) -> Implicit destDoc
         | _ -> failwith $"Link kind cannot be determined for {srcSym} symbol"
 
-    let private tryResolveSym (folder: Folder) (doc: Doc) (srcSym: Sym) : seq<Dest> =
+    let tryResolveSym (folder: Folder) (doc: Doc) (srcSym: Sym) : seq<Dest> =
         let complStyle = (Folder.configOrDefault folder).ComplWikiStyle()
 
         let scopedSym = Sym.scopedToDoc doc.Id srcSym

--- a/Marksman/Refs.fsi
+++ b/Marksman/Refs.fsi
@@ -50,5 +50,6 @@ module Dest =
     val scope: Dest -> Range
     val location: Dest -> Location
 
+    val tryResolveSym: Folder -> Doc -> Syms.Sym -> seq<Dest>
     val tryResolveElement: Folder -> Doc -> Element -> seq<Dest>
     val findElementRefs: bool -> Folder -> Doc -> Element -> seq<Doc * Element>

--- a/Tests/CodeActionTests.fs
+++ b/Tests/CodeActionTests.fs
@@ -1,0 +1,36 @@
+module Marksman.CodeActionTests
+
+open Ionide.LanguageServerProtocol.Types
+open Xunit
+
+open Marksman.Helpers
+open Marksman.Misc
+
+module CreateMissingFileTests =
+    [<Fact>]
+    let shouldCreateWhenNoFileExists () =
+        let doc1 = FakeDoc.Mk([| "# Doc 1"; "## Sub 1" |], path = "doc1.md")
+        let doc2 = FakeDoc.Mk([| "[[doc3]]" |], path = "doc2.md")
+        let folder = FakeFolder.Mk([ doc1; doc2 ])
+
+        let caCtx = { Diagnostics = [||]; Only = None; TriggerKind = None }
+
+        let ca =
+            CodeActions.createMissingFile (Range.Mk(0, 3, 0, 3)) caCtx doc2 folder
+
+        match ca with
+        | Some { name = "Create `doc3.md`" } -> Assert.True(true)
+        | _ -> Assert.True(false)
+
+    [<Fact>]
+    let shouldNotCreateWhenRefBrokenButFileExists () =
+        let doc1 = FakeDoc.Mk([| "# Doc 1"; "## Sub 1" |], path = "doc1.md")
+        let doc2 = FakeDoc.Mk([| "[[doc1#Sub 2]]" |], path = "doc2.md")
+        let folder = FakeFolder.Mk([ doc1; doc2 ])
+
+        let caCtx = { Diagnostics = [||]; Only = None; TriggerKind = None }
+
+        let ca =
+            CodeActions.createMissingFile (Range.Mk(0, 3, 0, 3)) caCtx doc2 folder
+
+        Assert.Equal(None, ca)

--- a/Tests/Tests.fsproj
+++ b/Tests/Tests.fsproj
@@ -30,6 +30,7 @@
         <Compile Include="ConnTest.fs" />
         <Compile Include="MMapTests.fs" />
         <Compile Include="LensesTests.fs" />
+        <Compile Include="CodeActionTests.fs" />
         <Compile Include="Program.fs" />
     </ItemGroup>
 


### PR DESCRIPTION
Previously, the code would assume lack of references meant the file doesn't exist. However, for references such as [[file#head]] this would also trigger when there's no `head` heading in an existing file `file`.

When someone used this code action it wiped out the existing file.

Now we extract the doc part and check that the doc exists.
