### PR TITLE
Update README.md - Fix broken link for Sublime Text

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,6 @@ LSP but it's not a part of the spec at least until and including v3.17.
 
 [eglot-marksman-pr]: https://github.com/joaotavora/eglot/pull/1013
 
-[sublime-marksman]: https://github.com/bitsper2nd/LSP-marksman
+[sublime-marksman]: https://github.com/sublimelsp/LSP-marksman
 
 [ale]: https://github.com/dense-analysis/ale


### PR DESCRIPTION
The existing link, <https://github.com/bitsper2nd/LSP-marksman>, throws a 404-not found error. The correct URL is now <https://github.com/sublimelsp/LSP-marksman>.