### PR TITLE
docs: update nvim-lspconfig link

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ LSP but it's not a part of the spec at least until and including v3.17.
 
 [original-zn]: https://github.com/artempyanykh/zeta-note
 
-[nvim-marksman]: https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#marksman
+[nvim-marksman]: https://github.com/neovim/nvim-lspconfig/blob/master/doc/configs.md#marksman
 
 [mason-nvim]: https://github.com/williamboman/mason.nvim
 


### PR DESCRIPTION
README uses an old link for nvim-lspconfig setup; updated to reflect the new file.

### Old:

![image](https://github.com/user-attachments/assets/3180b324-9859-4425-bb22-f79d3cd5d87d)

### New:

![image](https://github.com/user-attachments/assets/0b5d8265-c6ac-4110-80d1-99bc9750ebc9)