### PR TITLE
fix: Honor wiki link completion style in rename refactors

### DIFF
--- a/Marksman/Refactor.fs
+++ b/Marksman/Refactor.fs
@@ -114,11 +114,19 @@ let renameHeadingLink
         | WL { data = wl } ->
             let toEdit = if Element.isTitle srcHeading then wl.doc else wl.heading
 
+            // TODO: consolidate with the completion logic
+            let encodeFn =
+                if Element.isTitle srcHeading then
+                    match complStyle with
+                    | TitleSlug -> Slug.str
+                    | _ -> WikiEncoded.encodeAsString
+                else
+                    WikiEncoded.encodeAsString
+
+            let newText = encodeFn newTitle
+
             toEdit
-            |> Option.map (fun node -> {
-                Range = node.range
-                NewText = WikiEncoded.encodeAsString newTitle
-            })
+            |> Option.map (fun node -> { Range = node.range; NewText = newText })
         | ML { data = MdLink.IL(_, url, _) } ->
             let docUrl = url |> Option.map Url.ofUrlNode
 

--- a/Tests/RefactorTests.fs
+++ b/Tests/RefactorTests.fs
@@ -147,8 +147,8 @@ module RenameTests =
                     "doc1.md", [| Range.Mk(0, 2, 0, 7), "New Title" |]
                     "doc2.md",
                     [|
-                        Range.Mk(2, 2, 2, 7), "New Title"
-                        Range.Mk(1, 2, 1, 7), "New Title"
+                        Range.Mk(2, 2, 2, 7), "new-title"
+                        Range.Mk(1, 2, 1, 7), "new-title"
                     |]
                 ]
 


### PR DESCRIPTION
Stacked PRs:
 * __->__#362
 * #361


--- --- ---

### fix: Honor wiki link completion style in rename refactors


Currently, title-based wiki link completion style is "title-slug". This means that when renaming a title of the doc it should b "new-title" rather than "New Title".
