### PR TITLE
feat: Add a configuration option to treat level 1 headings as title

### DIFF
--- a/Tests/ConfigTests.fs
+++ b/Tests/ConfigTests.fs
@@ -2,6 +2,7 @@ module Marksman.ConfigTests
 
 open System.IO
 open System.Reflection
+open FSharpPlus.Data.Validation
 open Xunit
 
 open Marksman.Config
@@ -189,3 +190,18 @@ let testDefault () =
     let content = using (new StreamReader(content)) (fun f -> f.ReadToEnd())
     let parsed = Config.tryParse content
     Assert.Equal(Some Config.Default, parsed)
+
+[<Fact>]
+let testDefault_titleVsCompletionStyle () =
+    let content =
+        """
+[core]
+title_from_heading = false
+"""
+
+    let actual =
+        Config.tryParse content
+        |> Option.defaultWith (fun () -> failwith "Expected a successful parse")
+
+    Assert.False(actual.CoreTitleFromHeading())
+    Assert.Equal(ComplWikiStyle.FileStem, actual.ComplWikiStyle())

--- a/Tests/default.marksman.toml
+++ b/Tests/default.marksman.toml
@@ -17,6 +17,11 @@ markdown.file_extensions = ["md", "markdown"]
 # sync which result in slightly correpted state and are really hard
 # to diagnose.
 text_sync = "full"
+# When set to true, level 1 headings will be treated as document titles
+# (this includes an assumption of having a single title in the document).
+# Setting this to false automatically changes the default wiki link 
+# completion style to a file-based one.
+title_from_heading = true
 # Use incremental resolution of project-wide references.
 # This is much more efficient but is currently experimental
 incremental_references = false


### PR DESCRIPTION
Stacked PRs:
 * #371
 * #369
 * #368
 * #367
 * __->__#366
 * #364


--- --- ---

### feat: Add a configuration option to treat level 1 headings as title


Previously, "level 1 heading = title" was the default. Now there's a toggle for this.

The config option is not wired yet. This will be done separately.
