### PR TITLE
fix: Check for a bogus root folder in workspace/didChangeWorkspaceFolders request

### DIFF
--- a/Marksman/Folder.fsi
+++ b/Marksman/Folder.fsi
@@ -24,6 +24,7 @@ module Folder =
     val docs: Folder -> seq<Doc>
     val docCount: Folder -> int
 
+    val checkWorkspaceFolderWithWarn: FolderId -> bool
     val tryLoad: userConfig: option<Config> -> name: string -> FolderId -> option<Folder>
 
     val singleFile: doc: Doc -> config: option<Config> -> Folder

--- a/Marksman/State.fs
+++ b/Marksman/State.fs
@@ -180,7 +180,11 @@ module State =
                 for f in added do
                     let rootUri = UriWith.mkRoot f.Uri
 
-                    let folder = Folder.tryLoad userConfig f.Name rootUri
+                    let folder =
+                        if Folder.checkWorkspaceFolderWithWarn rootUri then
+                            Folder.tryLoad userConfig f.Name rootUri
+                        else
+                            None
 
                     match folder with
                     | Some folder -> yield folder


### PR DESCRIPTION
Stacked PRs:
 * __->__#380
 * #379
 * #378


--- --- ---

### fix: Check for a bogus root folder in workspace/didChangeWorkspaceFolders request


Sometimes, LSP clients can send bogus folders (CWD, or homedir) as part
of added folders in didChangeWorkspaceFolders. Whenever this happens
marksman treats the root as the real root of the project folders and
recursively scans/indexes mardown documents underneath.This is
problematic when such root is a homedir because it makes marksman scan
too much and potentially fail.

Fixes #377
Potentially, addresses #373 too