### PR TITLE
fix: Autocomplete doesn't lowercase wikilink titles anymore

### DIFF
--- a/Marksman/Misc.fs
+++ b/Marksman/Misc.fs
@@ -68,7 +68,7 @@ type String with
 
                 chunkState <- 1
 
-                sb <- sb.Append(Char.ToLower(char))
+                sb <- sb.Append(char)
             else if chunkState = 1 then
                 chunkState <- 2
 


### PR DESCRIPTION
This pull request stops the autocomplete from turning titles in wikilinks lowercase, closing #402 .