### PR TITLE
feat(folder): recognize Jujutsu workspaces by treating .jj as a workspace root marker (#434)

### DIFF
--- a/Marksman/Folder.fs
+++ b/Marksman/Folder.fs
@@ -254,7 +254,7 @@ module Folder =
 
         if Directory.Exists(root) then
             let markerFiles = [| ".marksman.toml" |]
-            let markerDirs = [| ".git"; ".hg"; ".svn" |]
+            let markerDirs = [| ".git"; ".hg"; ".svn"; ".jj" |]
 
             let hasMarkerFile () =
                 Array.exists (fun marker -> File.Exists(Path.Join(root, marker))) markerFiles


### PR DESCRIPTION
- Add .jj to markerDirs in Folder.isRealWorkspaceFolder
- Enables pure Jujutsu repos to be recognized as workspace roots without extra config

Closes #434