### PR TITLE
feat: Support wiki-style embedded image links (![[doc]])

### DIFF
--- a/Marksman/Parser.fs
+++ b/Marksman/Parser.fs
@@ -78,7 +78,7 @@ module Markdown =
     type WikiLinkParser() as this =
         inherit InlineParser()
 
-        do this.OpeningCharacters <- [| '[' |]
+        do this.OpeningCharacters <- [| '['; '!' |]
 
         override this.Match(processor, slice_) =
             let mutable docSpan: option<SourceSpan> = None
@@ -162,9 +162,24 @@ module Markdown =
                     | _ -> parseDoc offset
 
             // do the parsing (run the finite state machine)
-            let start = slice.Start
-            let offsetStart = processor.GetSourcePosition(start)
-            let hasParsedLink = parse ()
+            let start, offsetStart, hasParsedLink =
+                if slice.CurrentChar = '!' then
+                    let saved = slice
+                    slice.NextChar() |> ignore
+                    if slice.CurrentChar = '[' && slice.PeekChar() = '[' then
+                        let start = saved.Start
+                        let offsetStart = processor.GetSourcePosition(start)
+                        let hasParsedLink = parse ()
+                        start, offsetStart, hasParsedLink
+                    else
+                        slice <- saved
+                        (0, 0, false)
+                else
+                    let start = slice.Start
+                    let offsetStart = processor.GetSourcePosition(start)
+                    let hasParsedLink = parse ()
+                    start, offsetStart, hasParsedLink
+
             slice_ <- slice // update output parameter to modified slice state
 
             if hasParsedLink then


### PR DESCRIPTION
fixes https://github.com/artempyanykh/marksman/issues/196

This pull request updates the Markdown parser to improve its handling of wiki links, specifically adding support for links that begin with an exclamation mark (`!`). The most significant changes involve extending the parser to recognize and process these new link patterns.

**Enhancements to wiki link parsing:**

* The set of opening characters for the `WikiLinkParser` now includes both `'['` and `'!'`, allowing the parser to detect wiki links that start with an exclamation mark.
* The parsing logic has been updated to check for and correctly handle links starting with `'!'` followed by `[[`, ensuring these links are parsed using the same finite state machine as standard wiki links.