### PR TITLE
fix: workspace/didDeleteFiles multiple deletions in the same folder

### DIFF
--- a/Marksman/Server.fs
+++ b/Marksman/Server.fs
@@ -732,7 +732,7 @@ type MarksmanServer(client: MarksmanClient) =
                     >> Log.addContext "uri" uri
                 )
 
-                match State.tryFindFolderAndDoc uri state with
+                match State.tryFindFolderAndDoc uri newState with
                 | None -> ()
                 | Some(folder, doc) ->
                     match Folder.withoutDoc (Doc.id doc) folder with


### PR DESCRIPTION
The handling logic for `workspace/didDeleteFiles` does not properly handle multiple file deletions in the same folder.

Consider the following case:

```
foo/
  file1.md
  file2.md
  file3.md
```

1. Let `file3.md` reference (via wikilink), both `file1.md` and `file2.md`.
2. Both `file1.md` and `file2.md` are deleted, this is notified via `workspace/didDeleteFiles`.
3. Marksman loops through `[file://.../file1.md, file://.../file2.md]`
    1. The first time, `state -> folder with file1.md -> folder without file1.md ([file2.md, file3.md])`
    2. The second time, `state -> folder with file2.md -> folder without file2.md ([file1.md, file3.md])`
4. Thus your new state ends up being `[file1.md, file3.md]`, not the expected `[file3.md]`.

The fix is just to have it search `newState` and derive new folders from it rather than the old `state`.